### PR TITLE
Add view wrapper around Navigation Container

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
+import {
+  View,
+  StyleSheet
+} from 'react-native';
 
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
 
-import { Colors } from './styles';
+import { Colors, Layout } from './styles';
 
-import {Home} from './components/HomeScreen';
-import Placeholder from './components/PlaceholderScreen';
+import HomeScreen from './components/HomeScreen';
+import PlaceholderScreen from './components/PlaceholderScreen';
 
 import NavUtils from './utils/NavUtils';
 
@@ -24,32 +28,37 @@ export default class App extends React.Component<{}, State> {
 
   render() {
     return (
-      <NavigationContainer>
-        <Stack.Navigator
-          defaultScreenOptions={{
-            headerTintColor: Colors.white,
-          }}
-          screenOptions={{
-            presentation: 'transparentModal'
-          }}            
-        >
-        <Stack.Screen
-            name="Home"
-            component={Home}            
-            options={NavUtils.getHeaderOptions('Sat Signer')}
-          />
+      <View style={styles.container}>
+        <NavigationContainer>
+          <Stack.Navigator
+            defaultScreenOptions={{
+              headerTintColor: Colors.white,
+            }}
+          >
           <Stack.Screen
-            name="Placeholder1"
-            component={Placeholder}
-            options={NavUtils.getHeaderOptions('Placeholder 1')}
-          />
-          <Stack.Screen
-            name="Placeholder2"
-            component={Placeholder}
-            options={NavUtils.getHeaderOptions('Placeholder 2')}
-          />
-        </Stack.Navigator>
-      </NavigationContainer>
+              name="Home"
+              component={HomeScreen}            
+              options={NavUtils.getHeaderOptions('Sat Signer')}
+            />
+            <Stack.Screen
+              name="Placeholder1"
+              component={PlaceholderScreen}
+              options={NavUtils.getHeaderOptions('Placeholder 1')}
+            />
+            <Stack.Screen
+              name="Placeholder2"
+              component={PlaceholderScreen}
+              options={NavUtils.getHeaderOptions('Placeholder 2')}
+            />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </View>
     );
   }
 }
+
+const styles = StyleSheet.create({  
+  container: {
+    ...Layout.container.base,
+  }
+});

--- a/src/components/HomeScreen.tsx
+++ b/src/components/HomeScreen.tsx
@@ -17,7 +17,7 @@ interface Props {
 interface State {
 }
 
-export class Home extends React.PureComponent<Props, State> {
+export default class HomeScreen extends React.PureComponent<Props, State> {
 
   constructor(props: any) {
     super(props);

--- a/src/components/PlaceholderScreen.tsx
+++ b/src/components/PlaceholderScreen.tsx
@@ -7,7 +7,7 @@ import {
 
 import { Typography, Layout } from '../styles';
 
-export default (props: any) => {
+export default function PlaceholderScreen(props: any) {
   return (
     <View style={styles.container}>
       <View>

--- a/src/components/shared/Button.tsx
+++ b/src/components/shared/Button.tsx
@@ -7,7 +7,7 @@ import {
 
 import { Colors, Typography } from '../../styles';
 
-export default (props: any) => {
+export default function Button(props: any) {
   const styles = StyleSheet.create({  
     touchableOpacity: {
       borderRadius: 3,

--- a/src/components/shared/HeaderBackground.tsx
+++ b/src/components/shared/HeaderBackground.tsx
@@ -7,7 +7,7 @@ import LinearGradient from 'react-native-linear-gradient';
 
 import { Colors } from '../../styles';
 
-export default (props: any) => {
+export default function HeaderBackground(props: any) {
   const styles = StyleSheet.create({  
     header: {
       height: 75,

--- a/src/components/shared/HeaderTitle.tsx
+++ b/src/components/shared/HeaderTitle.tsx
@@ -5,7 +5,7 @@ import {
 
 import { Typography } from '../../styles';
 
-export default (props: any) => {
+export default function HeaderTitle(props: any) {
   const styles = StyleSheet.create({  
     heading: {
       ...Typography.textHighlight.x5,

--- a/src/utils/NavUtils.tsx
+++ b/src/utils/NavUtils.tsx
@@ -19,4 +19,5 @@ class NavUtils {
 }
 
 const navUtils = new NavUtils();
+
 export default navUtils;


### PR DESCRIPTION
Previously was using a tranparent modal setting to get rid of white flash seen when navigating between screens.  Wrapping in View with same background color is better solution.

Closes #15 