### PR TITLE
Update to use bdk-rn library

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,4 +1,6 @@
 PODS:
+  - bdk-rn (0.30.0):
+    - React
   - boost (1.76.0)
   - BVLinearGradient (2.8.3):
     - React-Core
@@ -377,9 +379,6 @@ PODS:
   - React-jsinspector (0.72.7)
   - React-logger (0.72.7):
     - glog
-  - react-native-bdk (0.0.1):
-    - React
-    - React-Core
   - react-native-encrypted-storage (4.0.3):
     - React-Core
   - react-native-safe-area-context (4.8.0):
@@ -505,6 +504,7 @@ PODS:
     - Yoga (~> 1.14)
 
 DEPENDENCIES:
+  - bdk-rn (from `../node_modules/bdk-rn`)
   - boost (from `../node_modules/react-native/third-party-podspecs/boost.podspec`)
   - BVLinearGradient (from `../node_modules/react-native-linear-gradient`)
   - DoubleConversion (from `../node_modules/react-native/third-party-podspecs/DoubleConversion.podspec`)
@@ -551,7 +551,6 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
-  - react-native-bdk (from `../node_modules/react-native-bdk`)
   - react-native-encrypted-storage (from `../node_modules/react-native-encrypted-storage`)
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - React-NativeModulesApple (from `../node_modules/react-native/ReactCommon/react/nativemodule/core/platform/ios`)
@@ -593,6 +592,8 @@ SPEC REPOS:
     - YogaKit
 
 EXTERNAL SOURCES:
+  bdk-rn:
+    :path: "../node_modules/bdk-rn"
   boost:
     :podspec: "../node_modules/react-native/third-party-podspecs/boost.podspec"
   BVLinearGradient:
@@ -638,8 +639,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
-  react-native-bdk:
-    :path: "../node_modules/react-native-bdk"
   react-native-encrypted-storage:
     :path: "../node_modules/react-native-encrypted-storage"
   react-native-safe-area-context:
@@ -686,6 +685,7 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
+  bdk-rn: 7a962524bfaffa1960b564f3a65993bb3c259f5e
   boost: 57d2868c099736d80fcd648bf211b4431e51a558
   BVLinearGradient: 880f91a7854faff2df62518f0281afb1c60d49a3
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
@@ -720,7 +720,6 @@ SPEC CHECKSUMS:
   React-jsiexecutor: c49502e5d02112247ee4526bc3ccfc891ae3eb9b
   React-jsinspector: 8baadae51f01d867c3921213a25ab78ab4fbcd91
   React-logger: 8edc785c47c8686c7962199a307015e2ce9a0e4f
-  react-native-bdk: 3b610000374c351e13443e42035273cd1c4bbfa2
   react-native-encrypted-storage: db300a3f2f0aba1e818417c1c0a6be549038deb7
   react-native-safe-area-context: d1c8161a1e9560f7066e8926a7d825eb57c5dab5
   React-NativeModulesApple: b6868ee904013a7923128892ee4a032498a1024a

--- a/package.json
+++ b/package.json
@@ -12,12 +12,11 @@
   "dependencies": {
     "@react-navigation/native": "^6.1.8",
     "@react-navigation/native-stack": "^6.9.14",
-    "@synonymdev/result": "^0.0.2",
     "adm-zip": "^0.5.9",
+    "bdk-rn": "^0.30.0",
     "is_js": "^0.9.0",
     "react": "18.2.0",
     "react-native": "0.72.7",
-    "react-native-bdk": "github:tmakerman/react-native-bdk#fix-walletstore-export",
     "react-native-encrypted-storage": "^4.0.3",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-safe-area-context": "^4.7.4",

--- a/src/components/accounts/AccountsContext.ts
+++ b/src/components/accounts/AccountsContext.ts
@@ -1,4 +1,4 @@
-import { Wallet } from 'react-native-bdk';
+// import { Wallet } from 'react-native-bdk';
 import { createContext } from 'react';
 
 import { Account, AccountSnapshot } from '../../models/Account';
@@ -8,7 +8,7 @@ export const AccountsContext = createContext({
   accounts: [],
   setCurrentAccount: (account: Account) => {},
   hasAccountWithName: (name: string) => true,
-  loadWalletFromMnemonic: async (mnemonic: string): Wallet => {},
-  getAccountSnapshot: async () => new AccountSnapshot(),
-  storeAccountSnapshot: async () => {}
+  loadWalletFromMnemonic: async (mnemonic: string) => {},
+  getAccountSnapshot: async (wallet: any) => new AccountSnapshot(),
+  storeAccountSnapshot: async (snapshot: AccountSnapshot) => {}
 });

--- a/src/components/accounts/ImportSeedScreen.tsx
+++ b/src/components/accounts/ImportSeedScreen.tsx
@@ -148,10 +148,10 @@ export default class ImportSeedScreen extends React.PureComponent<Props, State> 
                       const mnemonic = this.state.seedWords.join(' ');
                       console.log('mnemonic', mnemonic);
                 
-                      await loadWalletFromMnemonic(mnemonic);
+                      const wallet = await loadWalletFromMnemonic(mnemonic);
                       this.setState({checksumValid: true});
                 
-                      const snapshot = await getAccountSnapshot();
+                      const snapshot = await getAccountSnapshot(wallet);
                       await storeAccountSnapshot(snapshot);
 
                       this.props.navigation.navigate('AccountList');

--- a/src/components/shared/encrypted.ts
+++ b/src/components/shared/encrypted.ts
@@ -1,3 +1,5 @@
+// From https://github.com/xsats/react-native-bdk/blob/master/src/store/encrypted.ts
+
 /**
  * @fileOverview a module to wrap native secure key store apis
  */

--- a/src/components/shared/encrypted.ts
+++ b/src/components/shared/encrypted.ts
@@ -1,0 +1,38 @@
+/**
+ * @fileOverview a module to wrap native secure key store apis
+ */
+
+import EncryptedStorage from 'react-native-encrypted-storage';
+
+const VERSION = '1';
+
+function isString(o: any) {
+  return typeof o === 'string' || o instanceof String;
+}
+
+/**
+ * Store an item in the keychain.
+ * @param {string} key   The key by which to do a lookup
+ * @param {string} value The value to be stored
+ * @return {Promise<undefined>}
+ */
+export async function setItem(key: any, value: string) {
+  if (!isString(key) || !key || !isString(value)) {
+    throw new Error('Invalid args');
+  }
+  const vKey = `${VERSION}_${key}`;
+  await EncryptedStorage.setItem(vKey, value);
+}
+
+/**
+ * Read an item stored in the keychain.
+ * @param  {string} key      The key by which to do a lookup.
+ * @return {Promise<string>} The stored value
+ */
+export async function getItem(key: any) {
+  if (!isString(key) || !key) {
+    throw new Error('Invalid args');
+  }
+  const vKey = `${VERSION}_${key}`;
+  return await EncryptedStorage.getItem(vKey);
+}

--- a/src/components/shared/storage.ts
+++ b/src/components/shared/storage.ts
@@ -1,4 +1,4 @@
-import { WalletStore } from 'react-native-bdk';
+import WalletStore from './walletstore';
 
 import { Account } from '../../models/Account';
 

--- a/src/components/shared/walletstore.ts
+++ b/src/components/shared/walletstore.ts
@@ -1,3 +1,5 @@
+// From https://github.com/xsats/react-native-bdk/blob/master/src/store/walletstore.ts
+
 import * as encrypted from './encrypted';
 
 const WALLETS = 'bdk.wallets';

--- a/src/components/shared/walletstore.ts
+++ b/src/components/shared/walletstore.ts
@@ -1,0 +1,105 @@
+import * as encrypted from './encrypted';
+
+const WALLETS = 'bdk.wallets';
+
+interface Wallet {
+  external_descriptor: string;
+  internal_descriptor: string;
+}
+
+class WalletStore {
+  wallets: Wallet[];
+  tx_metadata: {};
+  constructor() {
+    this.wallets = [];
+    this.tx_metadata = {};
+  }
+
+  /**
+   * Wrapper for storage call.
+   *
+   * @param key
+   * @param value
+   * @returns {Promise<any>|Promise<any> | Promise<void> | * | Promise | void}
+   */
+  setItem(key: string, value: string) {
+    return encrypted.setItem(key, value);
+  }
+
+  /**
+   * Wrapper for storage call.
+   *
+   * @param key
+   * @returns {Promise<any>|*}
+   */
+  getItem(key: string) {
+    return encrypted.getItem(key);
+  }
+
+  /**
+   * Load all wallets from disk and
+   * maps them to `this.wallets`
+   *
+   * @returns {Promise.<boolean>}
+   */
+  async loadFromDisk() {
+    try {
+      let data = await this.getItem(WALLETS);
+      if (data !== null) {
+        console.log('typeof', typeof(data));
+        console.log('data', data);
+        const wallets: Wallet[] = JSON.parse(data);
+        if (!wallets) return false;
+        wallets.forEach((wallet) => this.wallets.push(wallet));
+        return true;
+      } else {
+        return false; // failed loading data or loading/decryptin data
+      }
+    } catch (error: any) {
+      console.log(error);
+      console.warn(error.message);
+      return false;
+    }
+  }
+
+  /**
+   * Retrieve wallet from store via external_descriptor and
+   * remove from `this.wallets`
+   *
+   * @param wallet {Wallet}
+   */
+  deleteWallet(wallet: Wallet) {
+    const privateDescriptor = wallet.external_descriptor;
+    const tempWallets: Wallet[] = [];
+
+    for (const value of this.wallets) {
+      if (value.external_descriptor === privateDescriptor) {
+        // the one we should delete
+        // nop
+      } else {
+        // the one we must keep
+        tempWallets.push(value);
+      }
+    }
+    this.wallets = tempWallets;
+  }
+
+  /**
+   * Saves wallet store to disk.
+   *
+   * @returns {Promise} Result of storage save
+   */
+  async saveToDisk() {
+    return this.setItem(WALLETS, JSON.stringify(this.wallets));
+  }
+
+  /**
+   * Fetch all wallets in `this.wallets`
+   * @returns {Array.<AbstractWallet>}
+   */
+  getWallets() {
+    return this.wallets;
+  }
+}
+
+export default WalletStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1934,7 +1934,7 @@
     deepmerge "^4.3.1"
     svgo "^3.0.2"
 
-"@synonymdev/result@^0.0.2":
+"@synonymdev/result@0.0.2":
   version "0.0.2"
   resolved "https://npm.artofcontext.com/@synonymdev%2fresult/-/result-0.0.2.tgz"
   integrity sha512-Ni5qknulcf350qfPVTw3DWXqT2i6K68BoFc18zlqIAj9YA2RUOIJsKTdemX31i3wSma5LRHVcGLESVga16iAag==
@@ -2570,6 +2570,15 @@ bcrypt-pbkdf@^1.0.0:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
+
+bdk-rn@^0.30.0:
+  version "0.30.0"
+  resolved "https://npm.artofcontext.com/bdk-rn/-/bdk-rn-0.30.0.tgz#d91de8dec7167e6732c3fec6d846afd9949fa1c4"
+  integrity sha512-9gOJnSvoow4IR5Ezs4vCgrY+9QhrQ0Umj0DXl03G/bCbjMHfiJTZK6v1I3c0e4pkJJLOTjdpr4iTKPJ1/BSm/w==
+  dependencies:
+    "@synonymdev/result" "0.0.2"
+    adm-zip "^0.5.9"
+    request "^2.88.2"
 
 bl@^4.1.0:
   version "4.1.0"
@@ -5977,16 +5986,6 @@ react-is@^18.0.0, react-is@^18.2.0:
   version "18.2.0"
   resolved "https://npm.artofcontext.com/react-is/-/react-is-18.2.0.tgz"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
-
-"react-native-bdk@github:tmakerman/react-native-bdk#fix-walletstore-export":
-  version "0.0.1"
-  resolved "git+ssh://git@github.com/tmakerman/react-native-bdk.git#b96cdf7f75e6f74c82aa51a39f443db189efe9f1"
-  dependencies:
-    "@synonymdev/result" "^0.0.2"
-    adm-zip "^0.5.9"
-    is_js "^0.9.0"
-    react-native-encrypted-storage "^4.0.3"
-    request "^2.88.2"
 
 react-native-encrypted-storage@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
Update to use `bdk-rn` from `react-native-bdk`.

* It’s being actively developed with multiple contributors and seems to have come a long way since @xsats was running into roadblocks
* [Peach2Peach/peach-app](https://github.com/Peach2Peach/peach-app) is in production using it
* It has some things that react-native-bdk does not have yet that I was looking for: ability to set script type via Descriptor APIs, ability to load multiple wallets in iOS
* Potentially more discoverable to others (linked from BDK website and has some blog posts there) and so likely to continue getting more development