### PR TITLE
[Android] Fix Strange Anchored Position When Zooming/Pinching

### DIFF
--- a/src/screens/AccountUtxoBubbles/hooks/useZoomGesture/index.tsx
+++ b/src/screens/AccountUtxoBubbles/hooks/useZoomGesture/index.tsx
@@ -370,8 +370,9 @@ export function useZoomGesture(
         }
       )
       .minDistance(0)
-      .minPointers(2)
-      .maxPointers(2);
+      // min/maxPointers is 1 because we are using 1 finger for panning
+      .minPointers(1)
+      .maxPointers(1);
 
     const pinchGesture = Gesture.Pinch()
       .onStart(() => {


### PR DESCRIPTION
Unlike in IOS which pinching/zooming is working fine. In Android however it's the translateX and translateY is changing while zooming/pinching causing the zooming is not anchored to a fixed position which is the center of the canvas.

Changing the number of pointer for panning solved this issue.