### PR TITLE
Make SSText more consistent between iOS and Android

### DIFF
--- a/apps/mobile/components/SSText.tsx
+++ b/apps/mobile/components/SSText.tsx
@@ -14,7 +14,7 @@ type SSTextProps = {
 
 type WeightStyle = {
   fontFamily: string
-  fontWeight: '200' | '300' | '400' | '500' | '600'
+  fontWeight: '200' | '300' | '400' | '500' | '700'
 }
 
 export default function SSText({
@@ -32,10 +32,10 @@ export default function SSText({
     if (color === 'muted') colorStyle = styles.textColorMuted
 
     let weightStyle: WeightStyle = styles.textRegular
-    if (weight === 'ultralight') weightStyle = { ...styles.textUltralight }
-    if (weight === 'light') weightStyle = { ...styles.textLight }
-    if (weight === 'medium') weightStyle = { ...styles.textMedium }
-    if (weight === 'bold') weightStyle = { ...styles.textBold }
+    if (weight === 'ultralight') weightStyle = styles.textUltralight
+    if (weight === 'light') weightStyle = styles.textLight
+    if (weight === 'medium') weightStyle = styles.textMedium
+    if (weight === 'bold') weightStyle = styles.textBold
 
     return StyleSheet.compose(
       {
@@ -90,6 +90,6 @@ const styles = StyleSheet.create({
   },
   textBold: {
     fontFamily: Typography.sfProTextBold,
-    fontWeight: '600'
+    fontWeight: '700'
   }
 })

--- a/apps/mobile/components/SSText.tsx
+++ b/apps/mobile/components/SSText.tsx
@@ -12,6 +12,11 @@ type SSTextProps = {
   center?: boolean
 } & React.ComponentPropsWithoutRef<typeof Text>
 
+type WeightStyle = {
+  fontFamily: string
+  fontWeight: '200' | '300' | '400' | '500' | '600'
+}
+
 export default function SSText({
   color = 'white',
   size = 'sm',
@@ -26,11 +31,11 @@ export default function SSText({
     if (color === 'black') colorStyle = styles.textColorBlack
     if (color === 'muted') colorStyle = styles.textColorMuted
 
-    let weightStyle = styles.textRegular
-    if (weight === 'ultralight') weightStyle = styles.textUltralight
-    if (weight === 'light') weightStyle = styles.textLight
-    if (weight === 'medium') weightStyle = styles.textMedium
-    if (weight === 'bold') weightStyle = styles.textBold
+    let weightStyle: WeightStyle = styles.textRegular
+    if (weight === 'ultralight') weightStyle = { ...styles.textUltralight }
+    if (weight === 'light') weightStyle = { ...styles.textLight }
+    if (weight === 'medium') weightStyle = { ...styles.textMedium }
+    if (weight === 'bold') weightStyle = { ...styles.textBold }
 
     return StyleSheet.compose(
       {
@@ -68,18 +73,23 @@ const styles = StyleSheet.create({
     textAlign: 'center'
   },
   textUltralight: {
-    fontFamily: Typography.sfProTextUltralight
+    fontFamily: Typography.sfProTextUltralight,
+    fontWeight: '200'
   },
   textLight: {
-    fontFamily: Typography.sfProTextLight
+    fontFamily: Typography.sfProTextLight,
+    fontWeight: '300'
   },
   textRegular: {
-    fontFamily: Typography.sfProTextRegular
+    fontFamily: Typography.sfProTextRegular,
+    fontWeight: '400'
   },
   textMedium: {
-    fontFamily: Typography.sfProTextMedium
+    fontFamily: Typography.sfProTextMedium,
+    fontWeight: '500'
   },
   textBold: {
-    fontFamily: Typography.sfProTextBold
+    fontFamily: Typography.sfProTextBold,
+    fontWeight: '600'
   }
 })


### PR DESCRIPTION
before:

<img width="968" alt="Screenshot at Jun 13 12-05-58" src="https://github.com/satsigner/satsigner/assets/25649761/7b704511-36d5-4f9c-a0bd-289d3c14fb08">

after:

<img width="930" alt="Screenshot at Jun 13 12-33-02" src="https://github.com/satsigner/satsigner/assets/25649761/725a0572-a1ea-4f36-b0dc-d8d2d7bcfddf">
