### PR TITLE
fix: unlock pin input not working

### DIFF
--- a/apps/mobile/app/unlock.tsx
+++ b/apps/mobile/app/unlock.tsx
@@ -41,8 +41,8 @@ export default function Unlock() {
     setPin(Array(PIN_SIZE).fill(''))
   }
 
-  async function handleOnFillEnded() {
-    const isPinValid = await validatePin(pin.join(''))
+  async function handleOnFillEnded(pinString?: string) {
+    const isPinValid = await validatePin(pinString || pin.join(''))
     if (isPinValid) {
       setLockTriggered(false)
       resetPinTries()
@@ -83,7 +83,7 @@ export default function Unlock() {
               pin={pin}
               setPin={setPin}
               autoFocus
-              onFillEnded={() => handleOnFillEnded()}
+              onFillEnded={handleOnFillEnded}
             />
           </Animated.View>
           {triesLeft !== null && (

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -41,10 +41,10 @@ export default function SSPinInput({
     event: NativeSyntheticEvent<TextInputKeyPressEventData>,
     index: number
   ) {
-    const key = event.nativeEvent.key;
+    const key = event.nativeEvent.key
     if (key === 'Backspace') {
       setIsBackspace(true)
-      const previousPinIndex = index - 1;
+      const previousPinIndex = index - 1
       if (previousPinIndex >= 0) {
         inputRefs.current[previousPinIndex]?.focus()
       }

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -15,7 +15,7 @@ type SSPinInputProps = {
   pin: string[]
   setPin: Dispatch<SetStateAction<string[]>>
   autoFocus?: boolean
-  onFillEnded?(): void
+  onFillEnded?: (pin?: string) => void
 }
 
 export default function SSPinInput({
@@ -41,14 +41,18 @@ export default function SSPinInput({
     event: NativeSyntheticEvent<TextInputKeyPressEventData>,
     index: number
   ) {
-    if (event.nativeEvent.key === 'Backspace') {
+    const key = event.nativeEvent.key;
+    if (key === 'Backspace') {
       setIsBackspace(true)
-      if (index - 1 >= 0) {
-        inputRefs.current[index - 1]?.focus()
+      const previousPinIndex = index - 1;
+      if (previousPinIndex >= 0) {
+        inputRefs.current[previousPinIndex]?.focus()
       }
     } else {
       if (index + 1 === PIN_SIZE) {
-        onFillEnded?.()
+        const newPin = [...pin]
+        newPin[index] = key
+        onFillEnded?.(newPin.join(''))
         Keyboard.dismiss()
       }
     }

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useRef, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react'
 import {
   Keyboard,
   NativeSyntheticEvent,
@@ -27,6 +27,16 @@ export default function SSPinInput({
   const inputRefs = useRef<TextInput[]>([])
   const [isBackspace, setIsBackspace] = useState(false)
 
+  function resetFocusOnClear() {
+    if (pin.join('') == '') {
+      inputRefs.current[0]?.focus()
+    }
+  }
+
+  useEffect(() => {
+    resetFocusOnClear()
+  }, [pin, resetFocusOnClear])
+
   function handleOnChangeText(text: string, index: number) {
     const newPin = [...pin]
     newPin[index] = text
@@ -43,20 +53,20 @@ export default function SSPinInput({
   ) {
     const key = event.nativeEvent.key
     const newPin = [...pin]
-    const isLastPin = index + 1 === PIN_SIZE;
+    const isLastPin = index + 1 === PIN_SIZE
     if (key === 'Backspace') {
       setIsBackspace(true)
       const previousPinIndex = index - 1
-      const currentPinNotEmpty = pin[index] !== ""
+      const currentPinNotEmpty = pin[index] !== ''
 
       if (currentPinNotEmpty) {
-        newPin[index] = ""
+        newPin[index] = ''
         setPin(newPin)
         return
       }
 
       if (previousPinIndex >= 0) {
-        newPin[previousPinIndex] = ""
+        newPin[previousPinIndex] = ''
         setPin(newPin)
         inputRefs.current[previousPinIndex]?.focus()
         return

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -43,15 +43,27 @@ export default function SSPinInput({
   ) {
     const key = event.nativeEvent.key
     const newPin = [...pin]
+    const isLastPin = index + 1 === PIN_SIZE;
     if (key === 'Backspace') {
       setIsBackspace(true)
       const previousPinIndex = index - 1
+      const currentPinNotEmpty = pin[index] !== ""
+
+      if (currentPinNotEmpty) {
+        newPin[index] = ""
+        setPin(newPin)
+        return
+      }
+
       if (previousPinIndex >= 0) {
         newPin[previousPinIndex] = ""
         setPin(newPin)
         inputRefs.current[previousPinIndex]?.focus()
+        return
       }
-    } else if (index + 1 === PIN_SIZE) {
+    }
+
+    if (isLastPin) {
       newPin[index] = key
       onFillEnded?.(newPin.join(''))
       Keyboard.dismiss()

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -27,15 +27,15 @@ export default function SSPinInput({
   const inputRefs = useRef<TextInput[]>([])
   const [isBackspace, setIsBackspace] = useState(false)
 
-  function resetFocusOnClear() {
-    if (pin.join('') == '') {
-      inputRefs.current[0]?.focus()
-    }
-  }
-
   useEffect(() => {
+    function resetFocusOnClear() {
+      if (pin.join('') === '') {
+        inputRefs.current[0]?.focus()
+      }
+    }
+
     resetFocusOnClear()
-  }, [pin, resetFocusOnClear])
+  }, [pin])
 
   function handleOnChangeText(text: string, index: number) {
     const newPin = [...pin]

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -42,19 +42,19 @@ export default function SSPinInput({
     index: number
   ) {
     const key = event.nativeEvent.key
+    const newPin = [...pin]
     if (key === 'Backspace') {
       setIsBackspace(true)
       const previousPinIndex = index - 1
       if (previousPinIndex >= 0) {
+        newPin[previousPinIndex] = ""
+        setPin(newPin)
         inputRefs.current[previousPinIndex]?.focus()
       }
-    } else {
-      if (index + 1 === PIN_SIZE) {
-        const newPin = [...pin]
-        newPin[index] = key
-        onFillEnded?.(newPin.join(''))
-        Keyboard.dismiss()
-      }
+    } else if (index + 1 === PIN_SIZE) {
+      newPin[index] = key
+      onFillEnded?.(newPin.join(''))
+      Keyboard.dismiss()
     }
   }
 


### PR DESCRIPTION
When the `handleOnFillEnded` is called, the state of the variable `pin` has not been updated yet even though `setPin` is called before `handleOnFillEnded`, so the value of pin is the previous one.

We add an optional parameter to `handleOnFillEnded`, which is the actual pin value itself, so when it is called it access this value instead of the outdated value stored in the state.