### PR TITLE
fix: account creation fail upon network error

### DIFF
--- a/apps/mobile/locales/en.json
+++ b/apps/mobile/locales/en.json
@@ -147,6 +147,7 @@
       "title": "Add Master Key",
       "masterKeyName": "Master Key Name",
       "hasAccountWithName": "Account with that name already exists",
+      "walletSyncFailed": "Failed to sync wallet. Make sure you have internet connection.",
       "generateNewSeed": {
         "title": "Generate New Secret Seed",
         "action": "Confirm Seed"


### PR DESCRIPTION
Upon any network error (no connection, host unreachable, poor bandwidth) the account creation would fail totally, and the user would have to restart the whole process. This is because the code tries to sync the wallet before adding it to the list of wallets.

We add the account first, then try to sync it in the foreground. If it fails, we warn the user wallet syncing failed about it.