### PR TITLE
Feat: Transaction BDK functions & Change default blockchain

### DIFF
--- a/apps/mobile/app/(authenticated)/account/[id]/signAndSend/feeSelection.tsx
+++ b/apps/mobile/app/(authenticated)/account/[id]/signAndSend/feeSelection.tsx
@@ -10,6 +10,7 @@ import SSMainLayout from '@/layouts/SSMainLayout'
 import SSVStack from '@/layouts/SSVStack'
 import { i18n } from '@/locales'
 import { useAccountsStore } from '@/store/accounts'
+import { useTransactionBuilderStore } from '@/store/transactionBuilder'
 import type { AccountSearchParams } from '@/types/navigation/searchParams'
 import { formatNumber } from '@/utils/format'
 
@@ -18,6 +19,7 @@ export default function FeeSelection() {
   const { id } = useLocalSearchParams<AccountSearchParams>()
 
   const getCurrentAccount = useAccountsStore((state) => state.getCurrentAccount)
+  const setFeeRate = useTransactionBuilderStore((state) => state.setFeeRate)
 
   const account = getCurrentAccount(id!)!
 
@@ -26,6 +28,7 @@ export default function FeeSelection() {
     useState(false)
 
   function handleOnPressPreviewTxMessage() {
+    setFeeRate(feeSelected)
     if (feeSelected > 5000)
       setInsufficientSatsModalVisible(true) // to remove
     else router.navigate(`/account/${id}/signAndSend/previewMessage`)

--- a/apps/mobile/app/(authenticated)/account/[id]/signAndSend/ioPreview.tsx
+++ b/apps/mobile/app/(authenticated)/account/[id]/signAndSend/ioPreview.tsx
@@ -50,7 +50,6 @@ export default function IOPreview() {
 
   const [addOutputModalVisible, setAddOutputModalVisible] = useState(false)
   const [cameraModalVisible, setCameraModalVisible] = useState(false)
-  const [outputAddress, setOutputAddress] = useState('')
 
   const utxosValue = (utxos: Utxo[]): number =>
     utxos.reduce((acc, utxo) => acc + utxo.value, 0)
@@ -72,7 +71,7 @@ export default function IOPreview() {
   }
 
   function handleAddOutputAndClose() {
-    addOutput({ to: outputAddress, amount: outputAmount, label: outputLabel })
+    addOutput({ to: outputTo, amount: outputAmount, label: outputLabel })
     setAddOutputModalVisible(false)
   }
 
@@ -325,7 +324,7 @@ export default function IOPreview() {
               <ScanIcon />
             </SSIconButton>
           }
-          onChangeText={(text) => setOutputAddress(text)}
+          onChangeText={(text) => setOutputTo(text)}
         />
         <SSVStack style={{ width: '100%' }}>
           <SSHStack style={{ width: '100%' }}>

--- a/apps/mobile/config/servers.ts
+++ b/apps/mobile/config/servers.ts
@@ -6,7 +6,7 @@ import {
 import { Backend } from '@/types/settings/blockchain'
 
 const ELECTRUM_BLOCKSTREAM_URL = 'ssl://electrum.blockstream.info:60002'
-const ESPLORA_MUTINYNET_URL = 'https://mutinynet.com/api'
+const MEMPOOL_SIGNET_URL = 'ssl://mempool.space:60602'
 
 type customBlockchainConfig = {
   retries?: number
@@ -40,4 +40,4 @@ function getBlockchainConfig(
   }
 }
 
-export { ELECTRUM_BLOCKSTREAM_URL, ESPLORA_MUTINYNET_URL, getBlockchainConfig }
+export { ELECTRUM_BLOCKSTREAM_URL, getBlockchainConfig, MEMPOOL_SIGNET_URL }

--- a/apps/mobile/store/blockchain.ts
+++ b/apps/mobile/store/blockchain.ts
@@ -3,7 +3,7 @@ import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
 import { getBlockchain } from '@/api/bdk'
-import { ESPLORA_MUTINYNET_URL, getBlockchainConfig } from '@/config/servers'
+import { getBlockchainConfig, MEMPOOL_SIGNET_URL } from '@/config/servers'
 import mmkvStorage from '@/storage/mmkv'
 import { type Backend, type Network } from '@/types/settings/blockchain'
 
@@ -30,9 +30,9 @@ type BlockchainAction = {
 const useBlockchainStore = create<BlockchainState & BlockchainAction>()(
   persist(
     (set, get) => ({
-      backend: 'esplora',
+      backend: 'electrum',
       network: 'signet',
-      url: ESPLORA_MUTINYNET_URL,
+      url: MEMPOOL_SIGNET_URL,
       timeout: 6,
       retries: 7,
       stopGap: 20,

--- a/apps/mobile/store/transactionBuilder.ts
+++ b/apps/mobile/store/transactionBuilder.ts
@@ -21,6 +21,7 @@ type TransactionBuilderAction = {
   addInput: (utxo: Utxo) => void
   removeInput: (utxo: Utxo) => void
   addOutput: (output: Omit<Output, 'localId'>) => void
+  setFeeRate: (feeRate: number) => void
 }
 
 const useTransactionBuilderStore = create<
@@ -61,6 +62,9 @@ const useTransactionBuilderStore = create<
         state.outputs.push({ localId: generateId(), ...output })
       })
     )
+  },
+  setFeeRate: (feeRate) => {
+    set({ feeRate })
   }
 }))
 


### PR DESCRIPTION
**In this PR**

- Change default `backend` to `electrum` 256eaab18efc1c2c2d9234661fb9b884a885d8d0
- Change default `network` to signet 256eaab18efc1c2c2d9234661fb9b884a885d8d0
- Change default `url` to `ssl://mempool.space:60602` 256eaab18efc1c2c2d9234661fb9b884a885d8d0

- Add transactionBuilder store `feeRate` fdc1f4de3bcadaa5eb209234fa76c06ea4a20b72

- Address BDK api functions to build, sign and broadcast a transaction 373de3b8b0d865e39f70d50e7768e0dceb7675d5

_Others_
- Fix problem in ioPreview page cdb37139d989c4b2a9a5b083257f6f8809c4aba3

Note: While trying to test building a transaction in satsigner app, the app crashes - might have something to do with [this](https://github.com/bitcoindevkit/bdk/issues/1796).

I am still investigating the problem. We can merge this for now since we are not yet using the functions due to that problem described in the note above.