### PR TITLE
feat: misspell tolerance in seed word autosuggestion

### DIFF
--- a/apps/mobile/app/(authenticated)/addMasterKey/importSeed.tsx
+++ b/apps/mobile/app/(authenticated)/addMasterKey/importSeed.tsx
@@ -115,6 +115,7 @@ export default function ImportSeed() {
       }
       return []
     }
+
     const readSeedFromClipboard = async () => {
       const text = (await Clipboard.getStringAsync()).trim()
       const seed = await checkTextHasSeed(text)
@@ -130,6 +131,7 @@ export default function ImportSeed() {
         await updateFingerprint()
       }
     }
+
     readSeedFromClipboard()
   }, [seedWordCount, setSeedWords, updateFingerprint])
 

--- a/apps/mobile/components/SSKeyboardWordSelector.tsx
+++ b/apps/mobile/components/SSKeyboardWordSelector.tsx
@@ -24,12 +24,35 @@ type WordInfo = {
   word: string
 }
 
+function wordStartMispells(haystack: string, needle: string) {
+  let mismatches = 0
+  for (let i = 0; i < needle.length; i += 1) {
+    // add a penalty which puts weight on misspells close to the word start
+    const penalty = (needle.length - i + 1) / 10
+    if (haystack.length <= i || needle[i] !== haystack[i])
+      mismatches += 1 + penalty
+  }
+  return mismatches
+}
+
 function getMatchingWords(wordStart: string): WordInfo[] {
+  const maxMisspells = 2
   let index = 0
 
-  return getWordList()
-    .map((w) => ({ index: index++, word: w }))
-    .filter((w) => w.word.indexOf(wordStart) === 0)
+  const result = getWordList()
+    .map((w) => ({
+      index: index++,
+      word: w,
+      mispells: wordStartMispells(w, wordStart)
+    }))
+    .filter((w) => w.mispells <= maxMisspells)
+
+  result.sort((a, b) => a.mispells - b.mispells)
+
+  return result.map((w) => ({
+    index: w.index,
+    word: w.word
+  }))
 }
 
 type SSKeyboardWordSelectorProps = {


### PR DESCRIPTION
If the user misspells a word, we still show suggestions.

Misspells closer to the word end receive less penalty.

We control the misspell tolerance by the `maxMisspells`. Currently the value is `2`, but the value can be float.