### PR TITLE
feat: load watch-only address wallet DRAFT REFERENCE

### DIFF
--- a/apps/mobile/api/bdk.ts
+++ b/apps/mobile/api/bdk.ts
@@ -137,7 +137,7 @@ async function getWalletFromMnemonic(
 
 async function getWalletFromDescriptor(
   externalDescriptor: Descriptor,
-  internalDescriptor: Descriptor,
+  internalDescriptor: Descriptor|null,
   network: Network
 ) {
   const dbConfig = await new DatabaseConfig().memory()

--- a/apps/mobile/utils/samples.ts
+++ b/apps/mobile/utils/samples.ts
@@ -1,2 +1,6 @@
 export const sampleSignetWalletSeed =
   'surprise winter sausage nation grape nerve cereal because price rally pride gym'
+
+// this is El Salvador public bitcoin P2SH address
+export const sampleMainnetWatchOnlyAddrDescriptor =
+  'sh(addr(32ixEdVJWo3kmvJGMTZq5jAQVZZeuwnqzo))'


### PR DESCRIPTION
This is meant to be **draft** only, because BDK does not support address descriptors yet.

**DRAFT REFERENCE**