### PR TITLE
Utxo selection for efficiency and privacy

### DIFF
--- a/apps/mobile/api/bdk.ts
+++ b/apps/mobile/api/bdk.ts
@@ -661,8 +661,8 @@ async function getLastUnusedAddressFromWallet(wallet: Wallet) {
   return newAddress
 }
 
-async function getScriptPubKeyFromAddress(address: string) {
-  const recipientAddress = await new Address().create(address)
+async function getScriptPubKeyFromAddress(address: string, network: Network) {
+  const recipientAddress = await new Address().create(address, network)
   return recipientAddress.scriptPubKey()
 }
 
@@ -675,7 +675,8 @@ async function buildTransaction(
     options: {
       rbf: boolean
     }
-  }
+  },
+  network: Network
 ) {
   const transactionBuilder = await new TxBuilder().create()
 
@@ -685,7 +686,7 @@ async function buildTransaction(
   await transactionBuilder.manuallySelectedOnly()
 
   for (const output of data.outputs) {
-    const recipient = await getScriptPubKeyFromAddress(output.to)
+    const recipient = await getScriptPubKeyFromAddress(output.to, network)
     await transactionBuilder.addRecipient(recipient, output.amount)
   }
 

--- a/apps/mobile/app/(authenticated)/(stacks)/account/[id]/index.tsx
+++ b/apps/mobile/app/(authenticated)/(stacks)/account/[id]/index.tsx
@@ -421,7 +421,6 @@ function DerivedAddresses({
               }}
               uppercase
               onPress={() => setChange(index === 1)}
-              disabled={index === 1}
               label={type}
               variant="outline"
             />

--- a/apps/mobile/app/(authenticated)/(stacks)/account/[id]/signAndSend/previewMessage.tsx
+++ b/apps/mobile/app/(authenticated)/(stacks)/account/[id]/signAndSend/previewMessage.tsx
@@ -1,3 +1,4 @@
+import { type Network } from 'bdk-rn/lib/lib/enums'
 import { Redirect, Stack, useLocalSearchParams, useRouter } from 'expo-router'
 import { useEffect, useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
@@ -11,6 +12,7 @@ import SSMainLayout from '@/layouts/SSMainLayout'
 import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { useAccountsStore } from '@/store/accounts'
+import { useBlockchainStore } from '@/store/blockchain'
 import { useTransactionBuilderStore } from '@/store/transactionBuilder'
 import { useWalletsStore } from '@/store/wallets'
 import { type AccountSearchParams } from '@/types/navigation/searchParams'
@@ -35,7 +37,7 @@ export default function PreviewMessage() {
     state.accounts.find((account) => account.id === id)
   )
   const wallet = useWalletsStore((state) => state.wallets[id!])
-
+  const network = useBlockchainStore((state) => state.network)
   const [messageId, setMessageId] = useState('')
 
   const [noKeyModalVisible, setNoKeyModalVisible] = useState(false)
@@ -44,14 +46,18 @@ export default function PreviewMessage() {
     async function getTransactionMessage() {
       if (!wallet) return
 
-      const transactionMessage = await buildTransaction(wallet, {
-        inputs: Array.from(inputs.values()),
-        outputs: Array.from(outputs.values()),
-        feeRate,
-        options: {
-          rbf
-        }
-      })
+      const transactionMessage = await buildTransaction(
+        wallet,
+        {
+          inputs: Array.from(inputs.values()),
+          outputs: Array.from(outputs.values()),
+          feeRate,
+          options: {
+            rbf
+          }
+        },
+        network as Network
+      )
 
       setMessageId(transactionMessage.txDetails.txid)
       setTxBuilderResult(transactionMessage)

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -27,7 +27,7 @@
     "@shopify/react-native-skia": "^1.3.2",
     "@tanstack/react-query": "^5.64.2",
     "assert": "^1.1.1",
-    "bdk-rn": "https://github.com/LtbLightning/bdk-rn#37b33a8282e35032e50a34aead94ecc829e66f45",
+    "bdk-rn": "https://github.com/LtbLightning/bdk-rn#bc918a5f58b2fb4a1c50bd21ba9206300edff43d",
     "bip21": "^3.0.0",
     "bip39": "^3.1.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -27,7 +27,7 @@
     "@shopify/react-native-skia": "^1.3.2",
     "@tanstack/react-query": "^5.64.2",
     "assert": "^1.1.1",
-    "bdk-rn": "^0.30.0",
+    "bdk-rn": "https://github.com/LtbLightning/bdk-rn#37b33a8282e35032e50a34aead94ecc829e66f45",
     "bip21": "^3.0.0",
     "bip39": "^3.1.0",
     "bitcoinjs-lib": "^6.1.7",

--- a/apps/mobile/tests/unit/utils/utxo.test.ts
+++ b/apps/mobile/tests/unit/utils/utxo.test.ts
@@ -220,15 +220,43 @@ describe('STONEWALL UTXO Selection Algorithm', () => {
   test('should calculate entropy correctly', () => {
     const mockSolution = {
       inputs: [
-        { value: 10000 },
-        { value: 20000 },
-        { value: 30000 },
-        { value: 40000 }
+        {
+          txid: 'tx1',
+          vout: 0,
+          value: 10000,
+          keychain: 'external' as const,
+          effectiveValue: 10000,
+          scriptType: 'p2wpkh' as const
+        },
+        {
+          txid: 'tx2',
+          vout: 0,
+          value: 20000,
+          keychain: 'external' as const,
+          effectiveValue: 20000,
+          scriptType: 'p2wpkh' as const
+        },
+        {
+          txid: 'tx3',
+          vout: 0,
+          value: 30000,
+          keychain: 'external' as const,
+          effectiveValue: 30000,
+          scriptType: 'p2wpkh' as const
+        },
+        {
+          txid: 'tx4',
+          vout: 0,
+          value: 40000,
+          keychain: 'external' as const,
+          effectiveValue: 40000,
+          scriptType: 'p2wpkh' as const
+        }
       ],
       outputs: [
-        { value: 50000, recipient: true },
-        { value: 25000 },
-        { value: 20000 }
+        { type: 'p2wpkh', value: 50000, recipient: true, size: 31 },
+        { type: 'p2wpkh', value: 25000, size: 31 },
+        { type: 'p2wpkh', value: 20000, size: 31 }
       ]
     }
 

--- a/apps/mobile/tests/unit/utils/utxo.test.ts
+++ b/apps/mobile/tests/unit/utils/utxo.test.ts
@@ -25,7 +25,6 @@ describe('Efficiency UTXO Selection Algorithm', () => {
     const target = 10000
     const feeRate = 1
     const result = selectUtxos(utxos, target, feeRate)
-    // expect(result).toEqual([utxos[2]])
     expect(result.inputs.length).toBe(1)
     expect(result.inputs[0].value).toBe(10000)
   })

--- a/apps/mobile/tests/unit/utils/utxo.test.ts
+++ b/apps/mobile/tests/unit/utils/utxo.test.ts
@@ -2,8 +2,8 @@ import { type Utxo } from '@/types/models/Utxo'
 import {
   calculateStonewallEntropy,
   distributeChangeWithPrivacy,
-  selectStonewallUtxos,
-  selectUtxos
+  selectEfficientUtxos,
+  selectStonewallUtxos
 } from '@/utils/utxo'
 
 describe('Efficiency UTXO Selection Algorithm', () => {
@@ -24,7 +24,7 @@ describe('Efficiency UTXO Selection Algorithm', () => {
     const utxos = createMockUtxos([10000, 20000, 30000])
     const target = 10000
     const feeRate = 1
-    const result = selectUtxos(utxos, target, feeRate)
+    const result = selectEfficientUtxos(utxos, target, feeRate)
     expect(result.inputs.length).toBe(1)
     expect(result.inputs[0].value).toBe(10000)
   })
@@ -34,7 +34,7 @@ describe('Efficiency UTXO Selection Algorithm', () => {
     const targetAmount = 10000
     const feeRate = 1
 
-    const result = selectUtxos(utxos, targetAmount, feeRate)
+    const result = selectEfficientUtxos(utxos, targetAmount, feeRate)
     if ('error' in result) {
       expect(result.error).toBe('Insufficient funds')
       expect(result.inputs.length).toBe(0)
@@ -46,7 +46,7 @@ describe('Efficiency UTXO Selection Algorithm', () => {
     const targetAmount = 4000
     const feeRate = 1
 
-    const result = selectUtxos(utxos, targetAmount, feeRate)
+    const result = selectEfficientUtxos(utxos, targetAmount, feeRate)
     expect(result.inputs.length).toBeGreaterThan(1)
     const totalSelected = result.inputs.reduce(
       (sum: number, utxo: Utxo) => sum + utxo.value,
@@ -60,7 +60,7 @@ describe('Efficiency UTXO Selection Algorithm', () => {
     const targetAmount = 25000
     const feeRate = 50 // Very high fee rate
 
-    const result = selectUtxos(utxos, targetAmount, feeRate)
+    const result = selectEfficientUtxos(utxos, targetAmount, feeRate)
     expect(result.fee).toBeGreaterThan(0)
     const totalSelected = result.inputs.reduce(
       (sum: number, utxo: Utxo) => sum + utxo.value,
@@ -74,7 +74,7 @@ describe('Efficiency UTXO Selection Algorithm', () => {
     const targetAmount = 8000
     const feeRate = 1
 
-    const result = selectUtxos(utxos, targetAmount, feeRate)
+    const result = selectEfficientUtxos(utxos, targetAmount, feeRate)
     // The optimal solution should select as few inputs as possible
     // while minimizing waste (change)
     expect(result.inputs.length).toBeLessThanOrEqual(3)
@@ -111,7 +111,7 @@ describe('Efficiency UTXO Selection Algorithm', () => {
     const targetAmount = 100
     const feeRate = 2
 
-    const result = selectUtxos(utxos, targetAmount, feeRate)
+    const result = selectEfficientUtxos(utxos, targetAmount, feeRate)
 
     // Should ignore tiny UTXOs that would cost more to spend than they're worth
     expect(result.inputs.length).toBe(1)
@@ -137,7 +137,6 @@ describe('STONEWALL UTXO Selection Algorithm', () => {
     }))
   }
 
-  // Test STONEWALL with sufficient funds
   test('should create a valid STONEWALL transaction with sufficient funds', () => {
     const utxos = createMockUtxos([10000, 20000, 30000, 40000, 50000, 60000], {
       scriptTypes: ['p2pkh', 'p2wpkh']

--- a/apps/mobile/tests/unit/utils/utxo.test.ts
+++ b/apps/mobile/tests/unit/utils/utxo.test.ts
@@ -1,0 +1,274 @@
+import { type Utxo } from '@/types/models/Utxo'
+import {
+  calculateStonewallEntropy,
+  distributeChangeWithPrivacy,
+  selectStonewallUtxos,
+  selectUtxos
+} from '@/utils/utxo'
+
+describe('Efficiency UTXO Selection Algorithm', () => {
+  // helper function to create mock utxos
+  function createMockUtxos(value: number[]) {
+    return value.map((value, index) => ({
+      txid: `tx${index}`,
+      vout: 0,
+      value,
+      label: '',
+      keychain: 'external' as const
+    }))
+  }
+
+  test('it should select a single utxo when it exactly matches the target amount', () => {
+    const utxos = createMockUtxos([10000, 20000, 30000])
+    const target = 10000
+    const feeRate = 1
+    const result = selectUtxos(utxos, target, feeRate)
+    // expect(result).toEqual([utxos[2]])
+    expect(result.inputs.length).toBe(1)
+    expect(result.inputs[0].value).toBe(10000)
+  })
+
+  test('should return error when there are insufficient funds', () => {
+    const utxos = createMockUtxos([1000, 2000])
+    const targetAmount = 10000
+    const feeRate = 1
+
+    const result = selectUtxos(utxos, targetAmount, feeRate)
+    expect(result.error).toBe('Insufficient funds')
+    expect(result.inputs.length).toBe(0)
+  })
+
+  test('should select multiple UTXOs when needed', () => {
+    const utxos = createMockUtxos([5000, 3000, 2000, 1000])
+    const targetAmount = 4000
+    const feeRate = 1
+
+    const result = selectUtxos(utxos, targetAmount, feeRate)
+    expect(result.inputs.length).toBeGreaterThan(1)
+    const totalSelected = result.inputs.reduce(
+      (sum: number, utxo: Utxo) => sum + utxo.value,
+      0
+    )
+    expect(totalSelected).toBeGreaterThanOrEqual(targetAmount + result.fee)
+  })
+
+  test('should handle high fee rates properly', () => {
+    const utxos = createMockUtxos([10000, 20000, 30000])
+    const targetAmount = 25000
+    const feeRate = 50 // Very high fee rate
+
+    const result = selectUtxos(utxos, targetAmount, feeRate)
+    expect(result.fee).toBeGreaterThan(0)
+    const totalSelected = result.inputs.reduce(
+      (sum, utxo) => sum + utxo.value,
+      0
+    )
+    expect(totalSelected - result.fee - targetAmount).toBeGreaterThanOrEqual(0)
+  })
+
+  test('should find optimal selection using branch and bound', () => {
+    const utxos = createMockUtxos([1000, 2000, 3000, 4000, 5000, 6000, 7000])
+    const targetAmount = 8000
+    const feeRate = 1
+
+    const result = selectUtxos(utxos, targetAmount, feeRate)
+    // The optimal solution should select as few inputs as possible
+    // while minimizing waste (change)
+    expect(result.inputs.length).toBeLessThanOrEqual(3)
+  })
+
+  test('should handle extremely small values correctly', () => {
+    const utxos = [
+      { txid: 'tx1', vout: 0, value: 1 }, // 1 satoshi
+      { txid: 'tx2', vout: 0, value: 2 }, // 2 satoshis
+      { txid: 'tx3', vout: 0, value: 10000 } // One normal UTXO
+    ]
+
+    const targetAmount = 100
+    const feeRate = 2
+
+    const result = selectUtxos(utxos, targetAmount, feeRate)
+
+    // Should ignore tiny UTXOs that would cost more to spend than they're worth
+    expect(result.inputs.length).toBe(1)
+    expect(result.inputs[0].txid).toBe('tx3')
+  })
+})
+
+describe('STONEWALL UTXO Selection Algorithm', () => {
+  // Helper functions for creating test UTXOs
+  function createMockUtxos(valueSets: number[][]) {
+    return valueSets.map((value, index) => ({
+      txid: `tx${index}`,
+      vout: 0,
+      value,
+      confirmations: 6,
+      scriptPubKey: 'mock-script'
+    }))
+  }
+
+  // Test STONEWALL with sufficient funds
+  test('should create a valid STONEWALL transaction with sufficient funds', () => {
+    const utxos = createMockUtxos([10000, 20000, 30000, 40000, 50000, 60000], {
+      scriptTypes: ['p2pkh', 'p2wpkh']
+    })
+    const targetAmount = 75000
+    const feeRate = 2
+
+    const result = selectStonewallUtxos(utxos, targetAmount, feeRate)
+
+    expect(result.error).toBeUndefined()
+    expect(result.inputs.length).toBeGreaterThanOrEqual(4) // STONEWALL requires multiple inputs
+    expect(result.outputs.length).toBeGreaterThanOrEqual(2) // At least recipient + change
+
+    // Verify total inputs cover outputs + fee
+    const totalInput = result.inputs.reduce(
+      (sum, input) => sum + input.value,
+      0
+    )
+    const totalOutput = result.outputs.reduce(
+      (sum, output) => sum + output.value,
+      0
+    )
+    expect(totalInput).toEqual(totalOutput + result.fee)
+
+    // Verify privacy score is calculated
+    expect(result.privacyScore).toBeGreaterThan(0)
+  })
+
+  // Test with insufficient funds
+  test('should return error when there are insufficient funds', () => {
+    const utxos = createMockUtxos([1000, 2000])
+    const targetAmount = 10000
+    const feeRate = 1
+
+    const result = selectStonewallUtxos(utxos, targetAmount, feeRate)
+
+    expect(result.error).toBe('Insufficient funds')
+  })
+
+  // Test change output distribution
+  test('should create well-distributed change outputs', () => {
+    const utxos = createMockUtxos([100000, 200000])
+    const targetAmount = 50000
+    const feeRate = 1
+
+    const result = selectStonewallUtxos(utxos, targetAmount, feeRate, {
+      minOutputs: 3 // Force at least 2 change outputs
+    })
+
+    expect(result.error).toBeUndefined()
+    expect(result.outputs.length).toBeGreaterThanOrEqual(3) // Recipient + at least 2 change
+
+    // Extract change outputs (non-recipient outputs)
+    const changeOutputs = result.outputs.filter((output) => !output.recipient)
+    expect(changeOutputs.length).toBeGreaterThanOrEqual(2)
+
+    // Verify change outputs are not identical (privacy feature)
+    const changeValues = changeOutputs.map((output) => output.value)
+    const uniqueValues = new Set(changeValues)
+    expect(uniqueValues.size).toBe(changeValues.length) // All change values should be unique
+  })
+
+  // Test entropy calculation
+  test('should calculate entropy correctly', () => {
+    const mockSolution = {
+      inputs: [
+        { value: 10000 },
+        { value: 20000 },
+        { value: 30000 },
+        { value: 40000 }
+      ],
+      outputs: [
+        { value: 50000, recipient: true },
+        { value: 25000 },
+        { value: 20000 }
+      ]
+    }
+
+    const entropy = calculateStonewallEntropy(mockSolution)
+
+    // Entropy should be a number between 0 and 100
+    expect(entropy).toBeGreaterThan(0)
+    expect(entropy).toBeLessThanOrEqual(100)
+  })
+
+  // Test change distribution function
+  test('should distribute change with privacy in mind', () => {
+    const totalChange = 100000
+    const numOutputs = 3
+    const dustThreshold = 546
+
+    const changeValues = distributeChangeWithPrivacy(
+      totalChange,
+      numOutputs,
+      dustThreshold
+    )
+
+    // Should create the requested number of outputs
+    expect(changeValues.length).toBe(numOutputs)
+
+    // Total should match the input amount
+    const sum = changeValues.reduce((acc, val) => acc + val, 0)
+    expect(sum).toBe(totalChange)
+
+    // All values should be above dust threshold
+    expect(changeValues.every((val) => val >= dustThreshold)).toBe(true)
+
+    // Values should be different (privacy feature)
+    const uniqueValues = new Set(changeValues)
+    expect(uniqueValues.size).toBe(changeValues.length)
+  })
+
+  // Test avoidRoundNumbers option
+  test('should avoid round numbers when configured', () => {
+    const utxos = createMockUtxos([100000, 200000])
+    const targetAmount = 50000
+    const feeRate = 1
+
+    // Test with avoidRoundNumbers = true
+    const resultWithAvoidance = selectStonewallUtxos(
+      utxos,
+      targetAmount,
+      feeRate,
+      {
+        avoidRoundNumbers: true,
+        minOutputs: 3
+      }
+    )
+
+    expect(resultWithAvoidance.error).toBeUndefined()
+
+    // Extract change outputs
+    const changeOutputs = resultWithAvoidance.outputs.filter(
+      (output) => !output.recipient
+    )
+
+    // Check if change amounts avoid round numbers (not divisible by 1000)
+    const notRound = changeOutputs.some((output) => output.value % 1000 !== 0)
+    expect(notRound).toBe(true)
+  })
+
+  // Test performance with large UTXO set
+  test('should handle large UTXO sets efficiently', () => {
+    // Create 100 UTXOs
+    const values = Array(100)
+      .fill()
+      .map((_, i) => 10000 + i * 1000)
+    const utxos = createMockUtxos(values, {
+      scriptTypes: ['p2pkh', 'p2wpkh', 'p2sh-p2wpkh']
+    })
+
+    const targetAmount = 500000
+    const feeRate = 2
+
+    const startTime = Date.now()
+    const result = selectStonewallUtxos(utxos, targetAmount, feeRate)
+    const endTime = Date.now()
+
+    // Should complete in a reasonable time (less than 2 seconds)
+    expect(endTime - startTime).toBeLessThan(2000)
+    expect(result.error).toBeUndefined()
+    expect(result.inputs.length).toBeGreaterThan(0)
+  })
+})

--- a/apps/mobile/tests/unit/utils/utxo.test.ts
+++ b/apps/mobile/tests/unit/utils/utxo.test.ts
@@ -123,7 +123,7 @@ describe('STONEWALL UTXO Selection Algorithm', () => {
   // Helper functions for creating test UTXOs
   function createMockUtxos(
     values: number[],
-    options?: { scriptTypes?: Array<'p2pkh' | 'p2wpkh' | 'p2sh-p2wpkh'> }
+    options?: { scriptTypes?: ('p2pkh' | 'p2wpkh' | 'p2sh-p2wpkh')[] }
   ) {
     return values.map((value, index) => ({
       txid: `tx${index}`,

--- a/apps/mobile/utils/utxo.ts
+++ b/apps/mobile/utils/utxo.ts
@@ -15,7 +15,7 @@ function getUtxoOutpoint(utxo: Utxo) {
   return `${utxo.txid}:${utxo.vout}`
 }
 
-interface UtxoOptions {
+type UtxoOptions = {
   dustThreshold: number
   inputSize: number
   changeOutputSize: number
@@ -29,7 +29,7 @@ interface UtxoOptions {
  * @param {Object} options - Additional options
  * @returns {Object} Selected UTXOs and change
  */
-function selectUtxos(
+function selectEfficientUtxos(
   utxos: _Utxo[],
   targetAmount: number,
   feeRate: number,
@@ -710,6 +710,6 @@ export {
   calculateStonewallEntropy,
   distributeChangeWithPrivacy,
   getUtxoOutpoint,
-  selectStonewallUtxos,
-  selectUtxos
+  selectEfficientUtxos,
+  selectStonewallUtxos
 }

--- a/apps/mobile/utils/utxo.ts
+++ b/apps/mobile/utils/utxo.ts
@@ -1,7 +1,707 @@
 import { type Utxo } from '@/types/models/Utxo'
 
+type ChangeOutput = {
+  type: string
+  value: number
+  size: number
+}
+
 function getUtxoOutpoint(utxo: Utxo) {
   return `${utxo.txid}:${utxo.vout}`
 }
 
-export { getUtxoOutpoint }
+/**
+ * Efficient UTXO Selection Algorithm
+ * @param {Array} utxos - Array of available UTXOs
+ * @param {Number} targetAmount - Amount to send in satoshis
+ * @param {Number} feeRate - Fee rate in satoshis per byte
+ * @param {Object} options - Additional options
+ * @returns {Object} Selected UTXOs and change
+ */
+function selectUtxos(
+  utxos: Utxo[],
+  targetAmount: number,
+  feeRate: number,
+  options = {}
+) {
+  // Default options
+  const defaultOptions = {
+    dustThreshold: 546, // Min UTXO value in satoshis (Bitcoin dust limit)
+    changeOutputSize: 34, // Size of change output in bytes
+    inputSize: 148 // Average size of input in bytes
+  }
+
+  const opts = { ...defaultOptions, ...options }
+
+  // Calculate cost to spend each UTXO
+  const costToSpend = opts.inputSize * feeRate
+
+  // Filter out UTXOs that would cost more to spend than they're worth
+  const spendableUtxos = utxos.filter((utxo) => utxo.value > costToSpend)
+
+  // If no UTXOs are spendable after filtering, use all UTXOs as fallback
+  const usableUtxos = spendableUtxos.length > 0 ? spendableUtxos : [...utxos]
+
+  // Sort UTXOs by value (ascending)
+  const sortedUtxos = [...usableUtxos].sort((a, b) => a.value - b.value)
+
+  // Store our selection results
+  const selectedUtxos = []
+  let selectedAmount = 0
+  let estimatedFee = 0
+  let change = 0
+
+  // First pass: Try exact match or closest match algorithm
+  const exactMatch = sortedUtxos.find((utxo) => {
+    // Account for the fee of using this single input
+    const txFee = (opts.inputSize + opts.changeOutputSize) * feeRate
+    const netValue = utxo.value - txFee
+
+    // Allow a small margin of error (dust threshold)
+    return Math.abs(netValue - targetAmount) < opts.dustThreshold
+  })
+
+  if (exactMatch) {
+    return {
+      inputs: [exactMatch],
+      fee: (opts.inputSize + opts.changeOutputSize) * feeRate,
+      change:
+        exactMatch.value -
+        targetAmount -
+        (opts.inputSize + opts.changeOutputSize) * feeRate
+    }
+  }
+
+  // Try branch and bound algorithm for optimal selection
+  const result = branchAndBoundUtxoSelection(
+    sortedUtxos,
+    targetAmount,
+    feeRate,
+    opts
+  )
+  if (result) {
+    return result
+  }
+
+  // Fallback to coin selection with accumulative strategy
+  // Start with largest UTXOs (reverse the sorted list) for fewer inputs
+  const reversedUtxos = [...sortedUtxos].reverse()
+
+  for (const utxo of reversedUtxos) {
+    selectedUtxos.push(utxo)
+    selectedAmount += utxo.value
+
+    // Calculate fee based on number of inputs and one output
+    estimatedFee =
+      (selectedUtxos.length * opts.inputSize + opts.changeOutputSize) * feeRate
+
+    // If we have enough funds (including fees)
+    if (selectedAmount >= targetAmount + estimatedFee) {
+      change = selectedAmount - targetAmount - estimatedFee
+
+      // If change is less than dust threshold, add it to the fee
+      if (change < opts.dustThreshold) {
+        change = 0
+        estimatedFee += change
+      }
+
+      break
+    }
+  }
+
+  // Insufficient funds
+  if (selectedAmount < targetAmount + estimatedFee) {
+    return { inputs: [], fee: 0, change: 0, error: 'Insufficient funds' }
+  }
+
+  return {
+    inputs: selectedUtxos,
+    fee: estimatedFee,
+    change
+  }
+}
+
+/**
+ * Branch and Bound UTXO selection algorithm
+ * Selects UTXOs from a pool to meet a target value (payment amount) while keeping the transaction efficient by avoiding unnecessary change outputs when possible.
+ */
+function branchAndBoundUtxoSelection(
+  utxos: Utxo[],
+  targetAmount: number,
+  feeRate: number,
+  opts: any
+) {
+  const MAX_TRIES = 1000000
+  const inputCost = opts.inputSize * feeRate
+
+  // Calculate the effective value of each UTXO (value minus cost to spend it)
+  const effectiveUtxos = utxos
+    .map((utxo) => ({
+      ...utxo,
+      effectiveValue: utxo.value - inputCost
+    }))
+    .filter((utxo) => utxo.effectiveValue > 0) // Filter out UTXOs that cost more to spend
+
+  if (effectiveUtxos.length === 0) {
+    return null
+  }
+
+  // Calculate total effective value
+  const totalEffectiveValue = effectiveUtxos.reduce(
+    (sum, utxo) => sum + utxo.effectiveValue,
+    0
+  )
+
+  // If total value is less than target, impossible to satisfy
+  if (totalEffectiveValue < targetAmount) {
+    return null
+  }
+
+  // If we have exact match, return it
+  const exactMatchSet = findExactMatch(effectiveUtxos, targetAmount)
+  if (exactMatchSet) {
+    const fee = exactMatchSet.length * inputCost
+    const actualValue = exactMatchSet.reduce(
+      (sum: any, utxo: { value: any }) => sum + utxo.value,
+      0
+    )
+
+    return {
+      inputs: exactMatchSet,
+      fee,
+      change: 0 // No change as we have exact match
+    }
+  }
+
+  // Apply Branch and Bound algorithm
+  let bestSelection: Utxo[] = []
+  let bestWaste = Infinity
+
+  // Function to search recursively
+  function search(
+    selection: Utxo[],
+    effectiveValue: number,
+    depth: number,
+    tries: number
+  ): any {
+    if (tries > MAX_TRIES) return false
+
+    if (effectiveValue >= targetAmount) {
+      // Calculate waste as the sum of all inputs minus target
+      const waste = effectiveValue - targetAmount
+
+      if (waste < bestWaste) {
+        bestSelection = [...selection]
+        bestWaste = waste
+      }
+
+      return true
+    }
+
+    if (depth >= effectiveUtxos.length) return false
+
+    // Try including this UTXO
+    selection.push(effectiveUtxos[depth])
+    const withResult = search(
+      selection,
+      effectiveValue + effectiveUtxos[depth].effectiveValue,
+      depth + 1,
+      tries + 1
+    )
+    selection.pop()
+
+    // Try excluding this UTXO
+    const withoutResult = search(
+      selection,
+      effectiveValue,
+      depth + 1,
+      tries + 1
+    )
+
+    return withResult || withoutResult
+  }
+
+  // Start search with empty selection
+  search([], 0, 0, 0)
+
+  // If we found a selection
+  if (bestSelection) {
+    const fee = bestSelection.length * inputCost
+    const actualValue = bestSelection.reduce(
+      (sum: number, utxo: Utxo) => sum + utxo.value,
+      0
+    )
+    const change = actualValue - targetAmount - fee
+
+    // If change is less than dust, add it to fee
+    if (change > 0 && change < opts.dustThreshold) {
+      return {
+        inputs: bestSelection,
+        fee: fee + change,
+        change: 0
+      }
+    }
+
+    return {
+      inputs: bestSelection,
+      fee,
+      change: change > 0 ? change : 0
+    }
+  }
+
+  return null
+}
+
+/**
+ * Find a subset of UTXOs that exactly match the target amount
+ */
+function findExactMatch(utxos: Utxo[], targetValue: number) {
+  // This uses dynamic programming to find subset sum
+  const n = utxos.length
+
+  // Create a map where the value is the subset
+  const dp = new Map()
+  dp.set(0, [])
+
+  for (let i = 0; i < n; i++) {
+    const utxo = utxos[i]
+    const effectiveValue = utxo.effectiveValue
+
+    // Create a copy of current dp map to avoid modifying during iteration
+    const currentDp = new Map(dp)
+
+    for (const [value, subset] of currentDp.entries()) {
+      const newValue = value + effectiveValue
+      if (!dp.has(newValue)) {
+        dp.set(newValue, [...subset, utxo])
+      }
+
+      if (newValue === targetValue) {
+        return dp.get(newValue)
+      }
+    }
+  }
+
+  // Check if we have an exact match for the target value
+  return dp.get(targetValue) || null
+}
+
+type StonewallOptions = {
+  recipientType?: string
+  dustThreshold?: number
+  minOutputs?: number
+  maxOutputs?: number
+  minInputs?: number
+  maxInputs?: number
+  sizeP2PKH?: number
+  sizeP2WPKH?: number
+  sizeP2SHP2WPKH?: number
+  outputSizeP2PKH?: number
+  outputSizeP2WPKH?: number
+  txOverhead?: number
+  maxAttempts?: number
+}
+
+/**
+ * STONEWALL UTXO Selection Algorithm
+ * * selects UTXOs to create two sets of inputs for a transaction, mimicking a CoinJoin-like structure to enhance privacy
+ * https://mempool.space/tx/94e5a9a734cdf45ca7387aa786e0c01463ee9102e7e6342aa1712fece0af114f
+ * Optimized for privacy by creating transactions that resemble multi-party transactions
+ * ideallshould support only P2WPKH and P2PKH script types
+ * Returns two UTxo sets with similar values
+ *
+ * @param {Array} utxos - Array of available UTXOs
+ * @param {Number} targetAmount - Amount to send in satoshis
+ * @param {Number} feeRate - Fee rate in satoshis per byte
+ * @param {Object} options - Additional options
+ * @returns {Object} Selected UTXOs, change outputs and metadata
+ */
+function selectStonewallUtxos(
+  utxos: any[],
+  targetAmount: number,
+  feeRate: number,
+  options: StonewallOptions = {}
+) {
+  // Default options
+  const defaultOptions = {
+    dustThreshold: 546,
+    minOutputs: 2,
+    maxOutputs: 4,
+    minInputs: 4,
+    maxInputs: 10,
+    sizeP2PKH: 148,
+    sizeP2WPKH: 68,
+    sizeP2SHP2WPKH: 91,
+    outputSizeP2PKH: 34,
+    outputSizeP2WPKH: 31,
+    txOverhead: 10,
+    maxAttempts: 1000
+  }
+
+  const opts = { ...defaultOptions, ...options }
+
+  // Check for insufficient funds early
+  const totalAvailable = utxos.reduce((sum, utxo) => sum + utxo.value, 0)
+  if (totalAvailable < targetAmount) {
+    return { error: 'Insufficient funds' }
+  }
+
+  // Filter UTXOs based on postmix option
+  let eligibleUtxos = [...utxos]
+
+  // Get input size based on script type
+  function getInputSize(utxo: { scriptType: any }) {
+    if (!utxo.scriptType) return opts.sizeP2PKH // Default to P2PKH
+
+    switch (utxo.scriptType) {
+      case 'p2wpkh':
+        return opts.sizeP2WPKH
+      case 'p2sh-p2wpkh':
+        return opts.sizeP2SHP2WPKH
+      default:
+        return opts.sizeP2PKH
+    }
+  }
+
+  // Get output size based on script type
+  function getOutputSize(scriptType: string) {
+    if (scriptType === 'p2wpkh') return opts.outputSizeP2WPKH
+    return opts.outputSizeP2PKH
+  }
+
+  // Group UTXOs by script type to help with fingerprinting avoidance
+  const utxosByType = {}
+  eligibleUtxos.forEach((utxo) => {
+    const type = utxo.scriptType || 'p2pkh'
+    if (!utxosByType[type]) {
+      utxosByType[type] = []
+    }
+    utxosByType[type].push(utxo)
+  })
+
+  // Sort UTXOs by size within each type
+  Object.keys(utxosByType).forEach((type) => {
+    utxosByType[type].sort(
+      (a: { value: number }, b: { value: number }) => a.value - b.value
+    )
+  })
+
+  // Try to find a suitable STONEWALL structure
+  let bestSolution = null
+  let bestPrivacyScore = 0
+
+  for (let attempt = 0; attempt < opts.maxAttempts; attempt++) {
+    // Step 1: Decide how many outputs to create (including recipient)
+    const numOutputs =
+      Math.floor(Math.random() * (opts.maxOutputs - opts.minOutputs + 1)) +
+      opts.minOutputs
+
+    // Step 2: Decide how many inputs to use
+    const numInputs =
+      Math.floor(Math.random() * (opts.maxInputs - opts.minInputs + 1)) +
+      opts.minInputs
+
+    // Step 3: Select random script types for diversity (if available)
+    const availableTypes = Object.keys(utxosByType).filter(
+      (type) => utxosByType[type].length > 0
+    )
+    if (availableTypes.length === 0) continue
+
+    // Simplified type selection
+    const selectedTypes = [availableTypes[0]]
+
+    // Step 4: Select inputs
+    const selectedInputs = []
+    let totalInputValue = 0
+
+    // Try to select inputs from different types
+    for (let i = 0; i < numInputs; i++) {
+      const type = selectedTypes[0] // Always use the first available type
+
+      if (utxosByType[type].length === 0) continue
+
+      // Select a random UTXO from this type
+      const typeUtxos = utxosByType[type]
+      const randomIndex = Math.floor(Math.random() * typeUtxos.length)
+      const selectedUtxo = typeUtxos[randomIndex]
+
+      selectedInputs.push(selectedUtxo)
+      totalInputValue += selectedUtxo.value
+
+      // Remove the selected UTXO from the available pool
+      utxosByType[type] = typeUtxos.filter(
+        (_: any, idx: number) => idx !== randomIndex
+      )
+    }
+
+    // Make sure we have enough funds with the selected inputs
+    const selectedInputSizes = selectedInputs.map(getInputSize)
+    const totalInputSize = selectedInputSizes.reduce(
+      (sum, size) => sum + size,
+      0
+    )
+
+    // Calculate base fee (inputs + recipient output + overhead)
+    const recipientOutputSize = getOutputSize(options.recipientType || 'p2pkh')
+    let baseFee =
+      (totalInputSize + recipientOutputSize + opts.txOverhead) * feeRate
+
+    // Calculate remaining amount for change outputs
+    const remainingAmount = totalInputValue - targetAmount - baseFee
+
+    // If we don't have enough funds, try again
+    if (remainingAmount <= 0) continue
+
+    // Step 5: Calculate change outputs
+    const changeOutputs: ChangeOutput[] = []
+    const numChangeOutputs = numOutputs - 1 // Excluding recipient
+
+    if (numChangeOutputs <= 0) continue
+
+    // Add sizes for change outputs
+    let totalChangeOutputSize = 0
+    const changeOutputSizes = []
+
+    for (let i = 0; i < numChangeOutputs; i++) {
+      // Randomly select script type for change
+      const changeType =
+        selectedTypes[Math.floor(Math.random() * selectedTypes.length)]
+      const outputSize = getOutputSize(changeType)
+      changeOutputSizes.push(outputSize)
+      totalChangeOutputSize += outputSize
+    }
+
+    // Recalculate fee with change outputs
+    const totalTxSize =
+      totalInputSize +
+      recipientOutputSize +
+      totalChangeOutputSize +
+      opts.txOverhead
+    const totalFee = totalTxSize * feeRate
+
+    // Calculate total available for change
+    const totalChangeAmount = totalInputValue - targetAmount - totalFee
+
+    // If total change is less than dust threshold * number of change outputs, try again
+    if (totalChangeAmount < opts.dustThreshold * numChangeOutputs) continue
+
+    // Distribute change amount across change outputs
+    for (let i = 0; i < numChangeOutputs; i++) {
+      let changeAmount
+
+      if (i === numChangeOutputs - 1) {
+        // Last change output gets the remainder
+        changeAmount =
+          changeOutputs.length > 0
+            ? totalChangeAmount -
+              changeOutputs.reduce((sum, output) => sum + output.value, 0)
+            : totalChangeAmount
+      } else {
+        // Calculate a target change value based on an uneven distribution
+        const baseAmount = totalChangeAmount / numChangeOutputs
+
+        // Apply variance to avoid equal change outputs
+        const variance = Math.random() * 0.4 - 0.2 // ±20%
+        changeAmount = Math.floor(baseAmount * (1 + variance))
+      }
+
+      // Ensure change amount is above dust threshold
+      if (changeAmount < opts.dustThreshold) continue
+
+      // Create change output
+      changeOutputs.push({
+        type: selectedTypes[Math.floor(Math.random() * selectedTypes.length)],
+        value: changeAmount,
+        size: changeOutputSizes[i]
+      })
+    }
+
+    // Make sure all change outputs are created and above dust
+    if (changeOutputs.length !== numChangeOutputs) continue
+
+    // Verify the total matches our calculations
+    const finalTotalOutput =
+      targetAmount +
+      changeOutputs.reduce((sum, output) => sum + output.value, 0)
+    const finalFee = totalInputValue - finalTotalOutput
+
+    // Calculate privacy score (higher is better)
+    let privacyScore = 0
+
+    // More inputs and outputs = better privacy
+    privacyScore += numInputs * 10
+    privacyScore += numOutputs * 15
+
+    // Variety of script types = better privacy
+    privacyScore +=
+      new Set(selectedInputs.map((utxo) => utxo.scriptType || 'p2pkh')).size *
+      20
+    privacyScore +=
+      new Set(changeOutputs.map((output) => output.type)).size * 20
+
+    // Balanced change outputs = better privacy
+    if (changeOutputs.length > 1) {
+      const values = changeOutputs.map((output) => output.value)
+      const maxValue = Math.max(...values)
+      const minValue = Math.min(...values)
+
+      // More balanced outputs = higher score
+      const balanceRatio = minValue / maxValue
+      privacyScore += balanceRatio * 50
+    }
+
+    // Avoid amount correlation with inputs
+    let hasExactInputMatch = false
+    for (const input of selectedInputs) {
+      if (
+        input.value === targetAmount ||
+        changeOutputs.some((output) => input.value === output.value)
+      ) {
+        hasExactInputMatch = true
+        break
+      }
+    }
+    if (!hasExactInputMatch) privacyScore += 30
+
+    // Update best solution if this one has a better privacy score
+    if (privacyScore > bestPrivacyScore) {
+      bestPrivacyScore = privacyScore
+      bestSolution = {
+        inputs: selectedInputs,
+        outputs: [
+          {
+            type: options.recipientType || 'p2pkh',
+            value: targetAmount,
+            recipient: true
+          },
+          ...changeOutputs
+        ],
+        fee: finalFee,
+        privacyScore: privacyScore,
+        txSize: totalTxSize
+      }
+    }
+  }
+
+  if (!bestSolution) {
+    return { error: 'Could not find a suitable STONEWALL structure' }
+  }
+
+  return bestSolution
+}
+
+/**
+ * Calculates the entropy of a STONEWALL transaction
+ * Higher entropy means better privacy
+ *
+ * @param {Object} solution - A STONEWALL transaction solution
+ * @returns {Number} Entropy score
+ */
+function calculateStonewallEntropy(solution: { inputs: any; outputs: any }) {
+  if (!solution || !solution.inputs || !solution.outputs) {
+    return 0
+  }
+
+  const inputs = solution.inputs
+  const outputs = solution.outputs
+
+  let entropy = 0
+
+  const allValues = [
+    ...inputs.map((i: { value: any }) => i.value),
+    ...outputs.map((o: { value: any }) => o.value)
+  ]
+  const valueDistribution = {}
+
+  allValues.forEach((value) => {
+    valueDistribution[value] = (valueDistribution[value] || 0) + 1
+  })
+
+  // Calculate entropy
+  const totalCount = allValues.length
+  Object.values(valueDistribution).forEach((count) => {
+    const probability = count / totalCount
+    entropy -= probability * Math.log2(probability)
+  })
+
+  // Scale entropy to a 0-100 score
+  const normalizedEntropy = Math.min(100, entropy * 25)
+
+  return normalizedEntropy
+}
+
+/**
+ * Creates different change output amounts that are not obviously related
+ *
+ * @param {Number} totalChange - Total change amount to distribute
+ * @param {Number} numOutputs - Number of change outputs to create
+ * @param {Number} dustThreshold - Minimum output value
+ * @returns {Array} Array of change output amounts
+ */
+function distributeChangeWithPrivacy(
+  totalChange: number,
+  numOutputs: number,
+  dustThreshold: number
+) {
+  if (numOutputs <= 0) return []
+  if (numOutputs === 1) return [totalChange]
+
+  // Make sure we have enough for all outputs
+  if (totalChange < dustThreshold * numOutputs) {
+    return [totalChange]
+  }
+
+  const changeOutputs = []
+  let remainingAmount = totalChange
+
+  // Create n-1 outputs with privacy-focused values
+  for (let i = 0; i < numOutputs - 1; i++) {
+    // Calculate remaining average
+    const avgRemaining = remainingAmount / (numOutputs - i)
+
+    // Create a non-round number with some variance
+    // Use different variance patterns to avoid fingerprinting
+    let variance
+    if (i % 3 === 0) {
+      // Some outputs significantly smaller
+      variance = 0.5 + Math.random() * 0.3
+    } else if (i % 3 === 1) {
+      // Some outputs slightly larger
+      variance = 1.1 + Math.random() * 0.2
+    } else {
+      // Some outputs close to average
+      variance = 0.9 + Math.random() * 0.2
+    }
+
+    // Calculate change amount
+    let changeAmount = Math.floor(avgRemaining * variance)
+
+    // Add some "noise" to avoid round numbers
+    const noise = Math.floor(Math.random() * 100) - 50
+    changeAmount += noise
+
+    // Ensure we don't create dust and leave enough for remaining outputs
+    const minRequired = dustThreshold * (numOutputs - i - 1)
+    if (changeAmount < dustThreshold) {
+      changeAmount = dustThreshold
+    } else if (remainingAmount - changeAmount < minRequired) {
+      changeAmount = remainingAmount - minRequired
+    }
+
+    changeOutputs.push(changeAmount)
+    remainingAmount -= changeAmount
+  }
+
+  // Add the final output with remaining amount
+  changeOutputs.push(remainingAmount)
+
+  return changeOutputs
+}
+
+export {
+  calculateStonewallEntropy,
+  distributeChangeWithPrivacy,
+  getUtxoOutpoint,
+  selectStonewallUtxos,
+  selectUtxos
+}

--- a/apps/mobile/utils/utxo.ts
+++ b/apps/mobile/utils/utxo.ts
@@ -4,6 +4,7 @@ type _Utxo = Utxo & {
   effectiveValue: number
   scriptType?: 'p2pkh' | 'p2wpkh' | 'p2sh-p2wpkh'
 }
+
 type ChangeOutput = {
   type: string
   value: number

--- a/apps/mobile/utils/utxo.ts
+++ b/apps/mobile/utils/utxo.ts
@@ -14,6 +14,12 @@ function getUtxoOutpoint(utxo: Utxo) {
   return `${utxo.txid}:${utxo.vout}`
 }
 
+interface UtxoOptions {
+  dustThreshold: number
+  inputSize: number
+  changeOutputSize: number
+}
+
 /**
  * Efficient UTXO Selection Algorithm
  * @param {Array} utxos - Array of available UTXOs
@@ -26,7 +32,7 @@ function selectUtxos(
   utxos: _Utxo[],
   targetAmount: number,
   feeRate: number,
-  options = {}
+  options?: UtxoOptions
 ) {
   // Default options
   const defaultOptions = {
@@ -125,12 +131,6 @@ function selectUtxos(
   }
 }
 
-interface BranchAndBoundOptions {
-  dustThreshold: number
-  inputSize: number
-  changeOutputSize: number
-}
-
 /**
  * Branch and Bound UTXO selection algorithm
  * Selects UTXOs from a pool to meet a target value (payment amount) while keeping the transaction efficient by avoiding unnecessary change outputs when possible.
@@ -139,7 +139,7 @@ function branchAndBoundUtxoSelection(
   utxos: _Utxo[],
   targetAmount: number,
   feeRate: number,
-  opts: BranchAndBoundOptions
+  opts: UtxoOptions
 ) {
   const MAX_TRIES = 1000000
   const inputCost = opts.inputSize * feeRate

--- a/apps/mobile/utils/utxo.ts
+++ b/apps/mobile/utils/utxo.ts
@@ -125,6 +125,12 @@ function selectUtxos(
   }
 }
 
+interface BranchAndBoundOptions {
+  dustThreshold: number
+  inputSize: number
+  changeOutputSize: number
+}
+
 /**
  * Branch and Bound UTXO selection algorithm
  * Selects UTXOs from a pool to meet a target value (payment amount) while keeping the transaction efficient by avoiding unnecessary change outputs when possible.
@@ -133,7 +139,7 @@ function branchAndBoundUtxoSelection(
   utxos: _Utxo[],
   targetAmount: number,
   feeRate: number,
-  opts: any
+  opts: BranchAndBoundOptions
 ) {
   const MAX_TRIES = 1000000
   const inputCost = opts.inputSize * feeRate
@@ -182,7 +188,7 @@ function branchAndBoundUtxoSelection(
     effectiveValue: number,
     depth: number,
     tries: number
-  ): any {
+  ): null | boolean {
     if (tries > MAX_TRIES) return false
 
     if (effectiveValue >= targetAmount) {
@@ -428,7 +434,7 @@ function selectStonewallUtxos(
 
       // Remove the selected UTXO from the available pool
       utxosByType[type] = typeUtxos.filter(
-        (_: any, idx: number) => idx !== randomIndex
+        (_: _Utxo, idx: number) => idx !== randomIndex
       )
     }
 
@@ -595,7 +601,10 @@ function selectStonewallUtxos(
  * @param {Object} solution - A STONEWALL transaction solution
  * @returns {Number} Entropy score
  */
-function calculateStonewallEntropy(solution: { inputs: any; outputs: any }) {
+function calculateStonewallEntropy(solution: {
+  inputs: _Utxo[]
+  outputs: ChangeOutput[]
+}) {
   if (!solution || !solution.inputs || !solution.outputs) {
     return 0
   }
@@ -606,8 +615,8 @@ function calculateStonewallEntropy(solution: { inputs: any; outputs: any }) {
   let entropy = 0
 
   const allValues = [
-    ...inputs.map((i: { value: any }) => i.value),
-    ...outputs.map((o: { value: any }) => o.value)
+    ...inputs.map((i: { value: number }) => i.value),
+    ...outputs.map((o: { value: number }) => o.value)
   ]
   const valueDistribution: { [key: number]: number } = {}
 

--- a/apps/mobile/utils/utxo.ts
+++ b/apps/mobile/utils/utxo.ts
@@ -352,7 +352,7 @@ function selectStonewallUtxos(
   }
 
   // Filter UTXOs based on postmix option
-  let eligibleUtxos = [...utxos]
+  const eligibleUtxos = [...utxos]
 
   // Get input size based on script type
   function getInputSize(utxo: Partial<Pick<_Utxo, 'scriptType'>>) {
@@ -448,7 +448,7 @@ function selectStonewallUtxos(
 
     // Calculate base fee (inputs + recipient output + overhead)
     const recipientOutputSize = getOutputSize(options.recipientType || 'p2pkh')
-    let baseFee =
+    const baseFee =
       (totalInputSize + recipientOutputSize + opts.txOverhead) * feeRate
 
     // Calculate remaining amount for change outputs
@@ -582,7 +582,7 @@ function selectStonewallUtxos(
           ...changeOutputs
         ],
         fee: finalFee,
-        privacyScore: privacyScore,
+        privacyScore,
         txSize: totalTxSize
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4049,10 +4049,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bdk-rn@^0.30.0:
-  version "0.30.0"
-  resolved "https://registry.npmjs.org/bdk-rn/-/bdk-rn-0.30.0.tgz#d91de8dec7167e6732c3fec6d846afd9949fa1c4"
-  integrity sha512-9gOJnSvoow4IR5Ezs4vCgrY+9QhrQ0Umj0DXl03G/bCbjMHfiJTZK6v1I3c0e4pkJJLOTjdpr4iTKPJ1/BSm/w==
+"bdk-rn@https://github.com/LtbLightning/bdk-rn#37b33a8282e35032e50a34aead94ecc829e66f45":
+  version "0.29.0"
+  resolved "https://github.com/LtbLightning/bdk-rn#37b33a8282e35032e50a34aead94ecc829e66f45"
   dependencies:
     "@synonymdev/result" "0.0.2"
     adm-zip "^0.5.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4049,9 +4049,9 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-"bdk-rn@https://github.com/LtbLightning/bdk-rn#37b33a8282e35032e50a34aead94ecc829e66f45":
-  version "0.29.0"
-  resolved "https://github.com/LtbLightning/bdk-rn#37b33a8282e35032e50a34aead94ecc829e66f45"
+"bdk-rn@https://github.com/LtbLightning/bdk-rn#bc918a5f58b2fb4a1c50bd21ba9206300edff43d":
+  version "0.31.0"
+  resolved "https://github.com/LtbLightning/bdk-rn#bc918a5f58b2fb4a1c50bd21ba9206300edff43d"
   dependencies:
     "@synonymdev/result" "0.0.2"
     adm-zip "^0.5.9"


### PR DESCRIPTION
## What does this PR do?

This PR attempts to create utxo selection functions for when a user wants to select UTXOs based on Efficiency or Privacy.

It takes cue from the Branch and Bound and Stonewall Utxo selection methods used in sparrow wallet
N/B - Some values are assumed and will be updated when integrating with wallet data in follow up PRs https://github.com/satsigner/satsigner/pull/114

<img width="666" alt="Screenshot 2025-03-14 at 23 05 03" src="https://github.com/user-attachments/assets/b85f15d3-6a35-4c7b-97b3-3cf8edbf33fd" />

End goal is to integrate the functions in follow up PRs to achieve a functionality like the screenshots below for Privacy and also for efficiency selection

<img width="868" alt="Screenshot 2025-03-14 at 23 18 53" src="https://github.com/user-attachments/assets/aaa78d5e-5b41-4e4c-8bea-becdc54b89de" />

<img width="761" alt="Screenshot 2025-03-14 at 23 23 43" src="https://github.com/user-attachments/assets/7995704a-0b3a-4d6e-864c-2235b32ed4cc" />
