### PR TITLE
fix: story book import type

### DIFF
--- a/apps/mobile/.storybook/main.ts
+++ b/apps/mobile/.storybook/main.ts
@@ -1,4 +1,4 @@
-import { StorybookConfig } from '@storybook/react-native'
+import type { StorybookConfig } from '@storybook/react-native'
 
 const main: StorybookConfig = {
   stories: ['../components/**/*.stories.?(ts|tsx|js|jsx)'],


### PR DESCRIPTION
The lack of the type keyword made it fail on Linux