### PR TITLE
Watch Only Mainnet + El Salvador address

### DIFF
--- a/apps/mobile/api/electrum.ts
+++ b/apps/mobile/api/electrum.ts
@@ -1,6 +1,6 @@
 import * as bitcoinjs from 'bitcoinjs-lib'
 // @ts-ignore @eslint-disable-next-line
-import RnElectrumClient from 'electrum-client'
+import BlueWalletElectrumClient from 'electrum-client'
 import TcpSocket from 'react-native-tcp-socket'
 
 import { type Transaction } from '@/types/models/Transaction'
@@ -85,6 +85,32 @@ type AddressInfo = {
   }
 }
 
+class ModifiedClient extends BlueWalletElectrumClient {
+  // INFO: Override the default timeout for keeping client alive
+  keepAlive() {
+    // @ts-ignore
+    if (this.timeout != null) clearTimeout(this.timeout)
+    const now = new Date().getTime()
+    // @ts-ignore
+    this.timeout = setTimeout(() => {
+      // @ts-ignore
+      if (this.timeLastCall !== 0 && now > this.timeLastCall + 500_000) {
+        const pingTimer = setTimeout(() => {
+          // @ts-ignore
+          this.onError(new Error('keepalive ping timeout'))
+        }, 900_000)
+
+        // @ts-ignore
+        this.server_ping()
+          .catch(() => {
+            clearTimeout(pingTimer)
+          })
+          .then(() => clearTimeout(pingTimer))
+      }
+    }, 50_000)
+  }
+}
+
 class BaseElectrumClient {
   client: any
   network: bitcoinjs.networks.Network
@@ -98,7 +124,9 @@ class BaseElectrumClient {
     const net = TcpSocket
     const tls = TcpSocket
     const options = {}
-    this.client = new RnElectrumClient(net, tls, port, host, protocol, options)
+
+    // @ts-ignore
+    this.client = new ModifiedClient(net, tls, port, host, protocol, options)
     this.network = bitcoinjsNetwork(network)
   }
 
@@ -139,7 +167,7 @@ class BaseElectrumClient {
       client: 'satsigner',
       version: '1.4'
     })
-    const timeoutPromise = new Promise((resolve, reject) =>
+    const timeoutPromise = new Promise((_resolve, reject) =>
       setTimeout(() => {
         reject(new Error('timeout'))
       }, timeout)

--- a/apps/mobile/hooks/useSyncAccountWithAddress.ts
+++ b/apps/mobile/hooks/useSyncAccountWithAddress.ts
@@ -140,10 +140,7 @@ function useSyncAccountWithAddress() {
           }
         })
       } else if (backend === 'electrum') {
-        const electrumClient = ElectrumClient.fromUrl(
-          url,
-          network
-        )
+        const electrumClient = ElectrumClient.fromUrl(url, network)
 
         await electrumClient.init()
         const addrInfo = await electrumClient.getAddressInfo(address)


### PR DESCRIPTION
In this PR:

- [x] fix bug when loading data from Esplora Client
- [x] fix bug when loading data from Electrum Client
- [x] increase electrum client connection timeout
- [x] ensure it loads El Salvador address data load using Esplora
- [x] ensure it loads El Salvador address data load using Electrum

**Note**: Tested El Salvador address using ssl://electrum.bitaroo.net:50002 as electrum backend

**Note**: Tested El Salvador address using https://mempool.space/api as Esplora Backend

**Note**: Mempool's Esplora backend rate limits its response to 50 transactions (for more, we would need to be premium users), therefore it won't load all transactions and the data is missing with their public backend.