### PR TITLE
Fix: Account derived address list info visibility

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/account/[id]/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/account/[id]/index.tsx
@@ -312,7 +312,16 @@ function DerivedAddresses({
     if (minItems <= addressCount) return
 
     if (account.addresses.length >= addressCount) {
-      setAddresses(account.addresses.slice(0, addressCount))
+      let newAddresses = await getWalletAddresses(
+        wallet!,
+        network!,
+        addressCount
+      )
+      newAddresses = parseAccountAddressesDetails({
+        ...account,
+        addresses: newAddresses
+      })
+      setAddresses(newAddresses)
       return
     }
 


### PR DESCRIPTION
**In this pull request**

![image](https://github.com/user-attachments/assets/f8baa609-d02e-4f91-a86c-a07ad5f363b5)

✅ Fixed following Issues
- [x] Account derived address list doesn't show TXs & UTXOs info at first visit