### PR TITLE
Account creation seed warning dialog

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/account/add/(common)/confirm/[keyIndex]/word/[index].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/account/add/(common)/confirm/[keyIndex]/word/[index].tsx
@@ -202,7 +202,7 @@ export default function Confirm() {
         visible={warningModalVisible}
         onClose={handleCloseWordsWarning}
       >
-        <SSVStack itemsCenter>
+        <SSVStack itemsCenter style={{ marginBottom: 20 }}>
           <SSHStack>
             <SSIconCheckCircle height={30} width={30} />
             <SSText size="3xl">
@@ -239,7 +239,7 @@ export default function Confirm() {
           <SSHStack>
             <SSIconWarning height={22} width={22} />
             <SSText uppercase size="xl" weight="bold">
-              Warning
+              {t('common.warning')}
             </SSText>
             <SSIconWarning height={22} width={22} />
           </SSHStack>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/account/add/(common)/confirm/[keyIndex]/word/[index].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/account/add/(common)/confirm/[keyIndex]/word/[index].tsx
@@ -72,6 +72,8 @@ export default function Confirm() {
     useState(false)
   const [warningModalVisible, setWarningModalVisible] = useState(false)
   const [skipModalVisible, setSkipModalVisible] = useState(false)
+  const [localMnemonicWordCount, setLocalMnemonicWordCount] =
+    useState(mnemonicWordCount)
 
   function handleOnPressSkip() {
     setSkipModalVisible(true)
@@ -117,6 +119,7 @@ export default function Confirm() {
       setLoadingAccount(false)
       router.dismiss(Number(index) + 3)
     }
+    setLocalMnemonicWordCount(mnemonicWordCount)
     clearKeyState()
   }
 
@@ -206,8 +209,8 @@ export default function Confirm() {
           <SSHStack>
             <SSIconCheckCircle height={30} width={30} />
             <SSText size="3xl">
-              {mnemonicWordCount} {t('common.of').toLowerCase()}{' '}
-              {mnemonicWordCount}
+              {localMnemonicWordCount} {t('common.of').toLowerCase()}{' '}
+              {localMnemonicWordCount}
             </SSText>
           </SSHStack>
           <SSText uppercase center>

--- a/apps/mobile/components/SSWarningModal.tsx
+++ b/apps/mobile/components/SSWarningModal.tsx
@@ -28,12 +28,14 @@ function SSWarningModal({ visible, onClose, children }: SSWarningModalProps) {
     <Modal visible={visible} transparent={false}>
       <SafeAreaView style={{ flex: 1, backgroundColor: Colors.black }}>
         <SSMainLayout black>
-          <ScrollView>{children}</ScrollView>
-          <SSButton
-            label={t('common.acknowledge')}
-            variant="secondary"
-            onPress={() => onClose()}
-          />
+          <ScrollView>
+            {children}
+            <SSButton
+              label={t('common.acknowledge')}
+              variant="secondary"
+              onPress={onClose}
+            />
+          </ScrollView>
         </SSMainLayout>
       </SafeAreaView>
     </Modal>


### PR DESCRIPTION
This pull request:

- [x] Enforces scroll on seed warning dialog displayed after seed confirmation
- [x] Fixes incorrect mnemonic word count. It was always 24, the default value, after we clear the key state when we finish creating the account
- [x] Does some ui improvements & i18 strings
