### PR TITLE
fix: esplora test timing out due to address with hundreds of transactions

### DIFF
--- a/apps/mobile/tests/int/api/esplora.test.ts
+++ b/apps/mobile/tests/int/api/esplora.test.ts
@@ -54,7 +54,7 @@ describe('Esplora tests', () => {
   })
 
   it('get address tx', async () => {
-    const address = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'
+    const address = 'bc1qs308e0rcv8aycdq3jcdxxu60ws3a6a5rcnhfyv'
     const resp = await esplora.getAddressTxs(address)
     expect(Array.isArray(resp)).toBe(true)
     expect(resp.length).toBeGreaterThan(0)
@@ -62,7 +62,7 @@ describe('Esplora tests', () => {
   })
 
   it('get address tx in mempool', async () => {
-    const address = 'bc1qxy2kgdygjrsqtzq2n0yrf2493p83kkfjhx0wlh'
+    const address = 'bc1qs308e0rcv8aycdq3jcdxxu60ws3a6a5rcnhfyv'
     const resp = await esplora.getAddressTxsInMempool(address)
     expect(Array.isArray(resp)).toBe(true)
     resp.forEach((tx) => {


### PR DESCRIPTION
Replace that address with another one with less transactions