### PR TITLE
fix: use little-endian instead of big-endian in tx decoded

### DIFF
--- a/apps/mobile/locales/en.json
+++ b/apps/mobile/locales/en.json
@@ -735,7 +735,7 @@
     "decoded.description.flag": "This is a 1-byte flag that follows the marker in transactions with witness data. It must be non-zero. It can be interpreted as a bitvector, with the unused bits available for future extensibility for other types of witness data.",
     "decoded.description.locktime": "This is a 4-byte little-endian number that specifies the absolute locktime of the transaction.",
     "decoded.description.marker": "This is a 1-byte marker (required to be '00') that serves as an indicator that the given transaction incorporates Segregated Witness (segwit) data.",
-    "decoded.description.txInHash": "This is the hash of the transaction input. Note that the transaction hash here is in big-endian format, whereas in other places it is typically represented in little-endian format.",
+    "decoded.description.txInHash": "This is the hash of the transaction input.",
     "decoded.description.txInIndex": "This is a 4-byte little-endian integer which represents the index of the specific output in the previous transaction.",
     "decoded.description.txInScript": "This is the unlocking script (scriptSig), providing proof of ownership of the bitcoins being spent.",
     "decoded.description.txInScriptVarInt": "This is a variable integer (VarInt) that denotes the length of the subsequent unlocking script.",

--- a/apps/mobile/utils/txDecoded.ts
+++ b/apps/mobile/utils/txDecoded.ts
@@ -111,8 +111,9 @@ export class TxDecoded extends bitcoinjs.Transaction {
 
   getInputHash(index: number): TxDecodedField {
     const bigEndianHash = this.ins[index].hash
-    const hex = bigEndianHash.toString('hex')
-    const value = Endian(bigEndianHash.toString('hex'))
+    const bigEndianHex = bigEndianHash.toString('hex')
+    const hex = bigEndianHexToLittleEndian(bigEndianHex)
+    const value = Endian(bigEndianHex)
     const field = TxField.TxInHash
     const placeholders = { input: index }
     return { hex, value, field, placeholders }
@@ -330,4 +331,12 @@ function Endian(hexStr: string) {
     result += hexStr.substr(i, 2)
   }
   return result
+}
+
+function bigEndianHexToLittleEndian(bigEndianHex: string) {
+  let littleEndianHex = ''
+  for (let i = bigEndianHex.length; i > 0; i -= 2) {
+    littleEndianHex += bigEndianHex[i-2] + bigEndianHex[i-1]
+  }
+  return littleEndianHex
 }


### PR DESCRIPTION
This PR shows txid as little-endian instead of big-endian