### PR TITLE
do not show warning page again after the user enters app for the first time

### DIFF
--- a/apps/mobile/app/warning.tsx
+++ b/apps/mobile/app/warning.tsx
@@ -16,7 +16,7 @@ export default function Warning() {
 
   function handleConfirm() {
     setShowWarning(false)
-    router.push('/')
+    router.replace('/')
   }
 
   return (


### PR DESCRIPTION
Do not show "warning" page by pressing 'back' button after the user  enters  the
app for the first time and press one  of  the  buttons  dismiss/acknowledge.  It
makes  no  sense  to  show  this  warning  again  after  the  user  has  already
acknowledged or dismissed the warning.