### PR TITLE
fix: prevent android forceDark mode from inverting bright colors

### DIFF
--- a/apps/mobile/android/app/src/main/res/values/styles.xml
+++ b/apps/mobile/android/app/src/main/res/values/styles.xml
@@ -4,6 +4,7 @@
     <item name="android:textColor">@android:color/black</item>
     <item name="android:editTextStyle">@style/ResetEditText</item>
     <item name="android:editTextBackground">@drawable/rn_edit_text_material</item>
+    <item name="android:forceDarkAllowed">false</item>
     <item name="colorPrimary">@color/colorPrimary</item>
     <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
   </style>


### PR DESCRIPTION
# PROBLEM

Some Android version will forcefully invert bright colors in apps when the user has enable dark mode regardless if the app has declared its theme to be already dark. This results in poor UI in some of our app screens.

## BEFORE THE FIX

### Unlock screen without virtual keyboard before the fix

![Unlock screen without virtual keyboard before the fix](https://github.com/user-attachments/assets/40cd0106-68ea-4bea-a859-eadac347998d)

### Unlock screen with virtual keyboard before the fix

![Unlock screen with virtual keyboard before the fix](https://github.com/user-attachments/assets/d16ea813-ac7e-4f9f-a14c-9f9169832a58)

## AFTER THE FIX

### Unlock screen with virtual keyboard after the fix

![Unlock screen with virtual keyboard after the fix](https://github.com/user-attachments/assets/c55844ee-e279-4230-a6ae-ffbc5e6a0498)
