### PR TITLE
URGENT fix inserting PIN from virtual keyboard not working

### DIFF
--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -25,7 +25,12 @@ const KEY_CODE_BACKSPACE = 67
 const KEY_CODE_LEFT = 21
 const DELETE_DELAY = 50 // delay in miliseconds between consecutive deletions
 
-function SSPinInput({ pin, setPin, autoFocus = true, onFillEnded }: SSPinInputProps) {
+function SSPinInput({
+  pin,
+  setPin,
+  autoFocus = true,
+  onFillEnded
+}: SSPinInputProps) {
   const inputRefs = useRef<TextInput[]>([])
   const [isBackspace, setIsBackspace] = useState(false)
   const [currentIndex, setCurrentIndex] = useState(0)


### PR DESCRIPTION
- [x] fixes PIN input on virtual keyboard
- [x] ensures autofocus is enabled so the virtual keyboard is always triggered at first render

Inserting PIN from virtual keyboad is currently not working and is causing all
wallet data to be deleted after 5 tries.

It did not work due to race condition: the `handleLastPin` was always called
before the state variable `pin` had been updated. It happened because the event
`onChangeText` was triggered after the event `onKeyPress`. The `onChangeText`
was responsible for updating the `pin` state variable, while `onKeyPress` was
responsible for calling `handleLastPin`.

The race condition has been solved by refactoring code such that the
`handleLastPin` is called by `onChangeText` and the updated `pin` variable is
passed as an argument to that function.