### PR TITLE
fix: require pin when exporting mnemonic seed even with skipPin dev option enabled

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/seedWords.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/seedWords.tsx
@@ -15,7 +15,6 @@ import SSSeedLayout from '@/layouts/SSSeedLayout'
 import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { useAccountsStore } from '@/store/accounts'
-import { useAuthStore } from '@/store/auth'
 import { Colors } from '@/styles'
 import { type AccountSearchParams } from '@/types/navigation/searchParams'
 import { decryptKeySecret } from '@/utils/account'
@@ -29,7 +28,6 @@ export default function SeedWordsPage() {
   const account = useAccountsStore((state) =>
     state.accounts.find((_account) => _account.id === accountId)
   )
-  const skipPin = useAuthStore((state) => state.skipPin)
 
   const [mnemonic, setMnemonic] = useState('')
   const [isLoading, setIsLoading] = useState(true)
@@ -65,12 +63,7 @@ export default function SeedWordsPage() {
   useEffect(() => {
     if (account && key) {
       setIsLoading(false)
-      if (skipPin) {
-        decryptMnemonic()
-      } else {
-        // Show PIN entry when skip PIN is disabled
-        setShowPinEntry(true)
-      }
+      setShowPinEntry(true)
     } else {
       setIsLoading(false)
     }

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
@@ -22,7 +22,6 @@ import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { getItem } from '@/storage/encrypted'
 import { useAccountsStore } from '@/store/accounts'
-import { useAuthStore } from '@/store/auth'
 import { useWalletsStore } from '@/store/wallets'
 import { Colors } from '@/styles'
 import { type Account, type Key, type Secret } from '@/types/models/Account'
@@ -50,8 +49,6 @@ export default function AccountSettings() {
   const removeAccountWallet = useWalletsStore(
     (state) => state.removeAccountWallet
   )
-
-  const skipPin = useAuthStore((state) => state.skipPin)
 
   const [scriptVersion, setScriptVersion] = useState<Key['scriptVersion']>(
     account?.keys[0]?.scriptVersion || 'P2WPKH'
@@ -109,12 +106,8 @@ export default function AccountSettings() {
   }
 
   function handleOnViewMnemonic() {
-    if (skipPin) {
-      setMnemonicModalVisible(true)
-    } else {
-      setPin(emptyPin())
-      setShowPinEntry(true)
-    }
+    setPin(emptyPin())
+    setShowPinEntry(true)
 
     // This will auto-focus the pin input after a little delay.
     // The delay is needed because the modal has to have become visible first.

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/multiSig/export/seedWords.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/multiSig/export/seedWords.tsx
@@ -18,7 +18,6 @@ import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { getItem } from '@/storage/encrypted'
 import { useAccountBuilderStore } from '@/store/accountBuilder'
-import { useAuthStore } from '@/store/auth'
 import { Colors } from '@/styles'
 import { aesDecrypt } from '@/utils/crypto'
 import { emptyPin } from '@/utils/pin'
@@ -29,7 +28,6 @@ export default function SeedWordsPage() {
   const [getAccountData] = useAccountBuilderStore(
     useShallow((state) => [state.getAccountData])
   )
-  const skipPin = useAuthStore((state) => state.skipPin)
 
   const [mnemonic, setMnemonic] = useState('')
   const [isLoading, setIsLoading] = useState(true)
@@ -107,17 +105,13 @@ export default function SeedWordsPage() {
         // In creation mode, no PIN needed - directly show mnemonic
         setMnemonic(key.secret.mnemonic)
         setShowPinEntry(false)
-      } else if (skipPin) {
-        // Automatically decrypt when skip PIN is enabled (settings mode)
-        decryptMnemonic()
       } else {
-        // Show PIN entry when skip PIN is disabled (settings mode)
         setShowPinEntry(true)
       }
     } else {
       setIsLoading(false)
     }
-  }, [accountData, key, skipPin, decryptMnemonic])
+  }, [accountData, key, decryptMnemonic])
 
   if (isLoading) {
     return (


### PR DESCRIPTION
When I added the `skipPin` developer option in the past, the goal was to improve DX by not requiring PIN input whenever the app reloaded (therefore making development faster). However, the goal was never to change security flows such as exporting mnemonic seeds or other sensitive data.

When a dev wants to test what would happen if the user performed such actions, he must first disable `skipPin` to experience what a regular user would experience, causing extra delay but the point of `skipPin` is to make development faster (by skipping pin upon frequent app reloads due to code changes), not slower.