### PR TITLE
Show total accounts balance in account list

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/accountList.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/accountList.tsx
@@ -1,6 +1,6 @@
 import { FlashList } from '@shopify/flash-list'
 import { Stack, useRouter } from 'expo-router'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Animated, Easing, ScrollView, View } from 'react-native'
 import { TouchableOpacity } from 'react-native-gesture-handler'
 import { toast } from 'sonner-native'
@@ -40,6 +40,7 @@ import useSyncAccountWithWallet from '@/hooks/useSyncAccountWithWallet'
 import useVerifyConnection from '@/hooks/useVerifyConnection'
 import SSHStack from '@/layouts/SSHStack'
 import SSMainLayout from '@/layouts/SSMainLayout'
+import SSStyledSatText from '@/components/SSStyledSatText'
 import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { getItem, setItem } from '@/storage/encrypted'
@@ -229,6 +230,14 @@ export default function AccountList() {
   const filteredAccounts = accounts.filter(
     (acc) => acc.network === tabs[tabIndex].key
   )
+
+  const totalBalance = useMemo(() => {
+    return filteredAccounts.reduce((value, account) => value + account.summary.balance, 0)
+  }, [filteredAccounts])
+
+  const totalSatsInMempoll = useMemo(() => {
+    return filteredAccounts.reduce((value, account) => value + account.summary.satsInMempool, 0)
+  }, [filteredAccounts])
 
   const ACCOUNT_CARD_HEIGHT = 160
   const SEPARATOR_VERTICAL = 32
@@ -804,6 +813,26 @@ export default function AccountList() {
             nextBlockFee={nextBlockFee}
             blockHeightSource={blockHeightSource}
           />
+          <SSHStack>
+            <SSHStack gap="xs" style={{ alignItems: 'baseline' }}>
+              <SSText size="2xxs" color="muted">
+                {t('accounts.totalBalance')}
+              </SSText>
+              <SSStyledSatText
+                amount={totalBalance}
+                textSize="xxs"
+              />
+            </SSHStack>
+            <SSHStack gap="xs" style={{ alignItems: 'baseline' }}>
+              <SSText size="2xxs" color="muted">
+                {t('accounts.satsInMempool').replace('\n', ' ')}
+              </SSText>
+              <SSStyledSatText
+                amount={totalSatsInMempoll}
+                textSize="xxs"
+              />
+            </SSHStack>
+          </SSHStack>
         </SSVStack>
         <SSButton
           label={t('account.add')}


### PR DESCRIPTION
In the Account List header, display brief wallet summary for current network wallets.

<img width="720" height="1561" alt="Screenshot2" src="https://github.com/user-attachments/assets/91f930fb-07aa-4fa7-85dc-6a99815b63c4" />
<img width="720" height="1561" alt="Screenshot1" src="https://github.com/user-attachments/assets/92b81894-6d2d-4a47-8d6d-ed6c88e1cd74" />
