### PR TITLE
Show wallet color from fingerprint

### DIFF
--- a/apps/mobile/components/SSAccountCard.tsx
+++ b/apps/mobile/components/SSAccountCard.tsx
@@ -12,7 +12,7 @@ import { Colors, Sizes } from '@/styles'
 import { type Account } from '@/types/models/Account'
 import { formatNumber } from '@/utils/format'
 
-import { SSIconChevronRight, SSIconEyeOn } from './icons'
+import { SSIconChevronRight, SSIconCircle, SSIconEyeOn } from './icons'
 import SSIconSync from './icons/SSIconSync'
 import SSStyledSatText from './SSStyledSatText'
 import SSText from './SSText'
@@ -169,12 +169,23 @@ function SSAccountCard({ account, onPress }: SSAccountCardProps) {
       <SSHStack justifyBetween style={{ position: 'relative' }}>
         <SSVStack gap={platform === 'android' ? 'none' : 'xxs'}>
           {account.keys[0].creationType === 'importAddress' ? null : (
-            <SSText
-              size="xs"
-              style={{ color: Colors.gray[500], lineHeight: 10 }}
-            >
-              {fingerprint || '-'}
-            </SSText>
+            <SSHStack gap="xs" style={{ alignItems: 'flex-start' }}>
+              {fingerprint && (
+                <SSIconCircle
+                  size={9}
+                  fill={`#${fingerprint.slice(0, 6)}`}
+                />
+              )}
+              <SSText
+                size="xs"
+                style={{
+                  color: Colors.gray[500],
+                  lineHeight: 10
+                }}
+              >
+                {fingerprint || '-'}
+              </SSText>
+            </SSHStack>
           )}
           <SSHStack gap="sm">
             <SSText size="lg" color="muted">

--- a/apps/mobile/components/icons/SSIconCircle.tsx
+++ b/apps/mobile/components/icons/SSIconCircle.tsx
@@ -1,0 +1,22 @@
+import Svg, { Circle, type SvgProps } from 'react-native-svg'
+
+type IconProps = Pick<SvgProps, 'fill' | 'stroke'> & {
+  size: SvgProps['height']
+}
+
+export default function SSIconCircle({ size, fill, stroke }: IconProps) {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={fill}
+      stroke={stroke}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <Circle cx="12" cy="12" r="10"/>
+    </Svg>
+  )
+}

--- a/apps/mobile/components/icons/index.tsx
+++ b/apps/mobile/components/icons/index.tsx
@@ -15,6 +15,7 @@ import SSIconChevronDown from './SSIconChevronDown'
 import SSIconChevronLeft from './SSIconChevronLeft'
 import SSIconChevronRight from './SSIconChevronRight'
 import SSIconChevronUp from './SSIconChevronUp'
+import SSIconCircle from './SSIconCircle'
 import SSIconCircleX from './SSIconCircleX'
 import SSIconCircleXThin from './SSIconCircleXThin'
 import SSIconClose from './SSIconClose'
@@ -108,6 +109,7 @@ export {
   SSIconChevronLeft,
   SSIconChevronRight,
   SSIconChevronUp,
+  SSIconCircle,
   SSIconCircleX,
   SSIconCircleXThin,
   SSIconClose,

--- a/apps/mobile/locales/en.json
+++ b/apps/mobile/locales/en.json
@@ -354,6 +354,7 @@
     "satsInMempool": "Sats in\nMempool",
     "spendableOutputs": "Spendable\nOutputs",
     "totalTransactions": "Total\nTransactions",
+    "totalBalance": "Total Balance",
     "txs": "Txs",
     "unspentSats": "Sats",
     "utxos": "UTXOs",


### PR DESCRIPTION
This shows a circle unique to the wallet fingerprint, just as npub profile color. Helps quickly identify wallet by its color.

<img width="720" height="1572" alt="Screenshot3" src="https://github.com/user-attachments/assets/dabb625d-ad33-4154-bfa3-9e7f65163cf9" />
