### PR TITLE
Security enhancement (nostr sync): show warning about implications of trusting new devices

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/nostr/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/nostr/index.tsx
@@ -193,6 +193,9 @@ export default function NostrSync() {
   const [syncingMessageIndex, setSyncingMessageIndex] = useState(0)
   const syncingMessage = SYNCING_MESSAGE_KEYS[syncingMessageIndex]
 
+  const [trustMemberModalVisible, setTrustMemberModalVisible] = useState(false)
+  const [trustMember, setTrustMember] = useState('')
+
   useEffect(() => {
     if (!isSyncing) {
       setSyncingMessageIndex(0)
@@ -591,6 +594,21 @@ export default function NostrSync() {
     updateAccountNostrCallback,
     setSyncing
   ])
+
+  function showTrustMemberModal(npub: string) {
+    setTrustMember(npub)
+    setTrustMemberModalVisible(true)
+  }
+
+  function confirmTrustMember() {
+    toggleMember(trustMember)
+    setTrustMemberModalVisible(false)
+  }
+
+  const handleToggleMember = useCallback((npub: string) => {
+    if (!selectedMembers.has(npub)) showTrustMemberModal(npub)
+    else toggleMember(npub)
+  }, [toggleMember, selectedMembers])
 
   const toggleMember = useCallback(
     (npub: string) => {
@@ -1123,7 +1141,9 @@ export default function NostrSync() {
                                   ? 'Distrust'
                                   : 'Trust'
                               }
-                              onPress={() => toggleMember(member.npub)}
+                              onPress={() => {
+                                handleToggleMember(member.npub)
+                              }}
                               disabled={isSyncing}
                             />
                           </SSHStack>
@@ -1278,6 +1298,33 @@ export default function NostrSync() {
             onPress={handleClearCaches}
             variant="danger"
             disabled={isLoading}
+          />
+        </SSVStack>
+      </SSModal>
+      <SSModal
+        visible={trustMemberModalVisible}
+        onClose={() => setTrustMemberModalVisible(false)}
+        showLabel={false}
+        fullOpacity
+      >
+        <SSVStack
+          style={{
+            flex: 1,
+            height: '100%',
+            justifyContent: 'center'
+          }}
+        >
+          <SSText center size="md">
+            {t('account.nostrSync.memberConfirmNew')}
+          </SSText>
+          <SSButton
+            onPress={confirmTrustMember}
+            label={t('common.yes')}
+          />
+          <SSButton
+            onPress={() => setTrustMemberModalVisible(false)}
+            label={t('common.cancel')}
+            variant='secondary'
           />
         </SSVStack>
       </SSModal>

--- a/apps/mobile/components/SSModal.tsx
+++ b/apps/mobile/components/SSModal.tsx
@@ -13,6 +13,7 @@ type SSModalProps = {
   fullOpacity?: boolean
   closeButtonVariant?: SSButtonProps['variant']
   label?: string
+  showLabel?: boolean
   onClose(): void
   children: React.ReactNode
 }
@@ -22,6 +23,7 @@ function SSModal({
   fullOpacity = false,
   closeButtonVariant = 'ghost',
   label = t('common.cancel'),
+  showLabel = true,
   onClose,
   children
 }: SSModalProps) {
@@ -39,7 +41,7 @@ function SSModal({
         <View style={styles.container}>
           <SSVStack justifyBetween itemsCenter style={styles.innerContainer}>
             {children}
-            {label && (
+            {showLabel && label && (
               <SSButton
                 label={label}
                 variant={closeButtonVariant}

--- a/apps/mobile/locales/en.json
+++ b/apps/mobile/locales/en.json
@@ -206,6 +206,7 @@
     "nostrSync.loadingKeys": "Loading keys...",
     "nostrSync.lookForMoreMembers": "Look for more members",
     "nostrSync.manageRelays": "Manage relays (%{count})",
+    "nostrSync.memberConfirmNew": "Trusting this device means all labels of this wallet will be shared with the device.\n\nDo you want to proceed?",
     "nostrSync.members": "Found Members",
     "nostrSync.messageReceivedReadySign": "Transaction received! Ready to sign.",
     "nostrSync.mnemonicPassphrase": "Mnemonic Passphrase (optional)",


### PR DESCRIPTION
When the user clicks to "trust device" on Nostr Sync, the following modal will be shown:

<img width="720" height="1489" alt="Screenshot_2026040901" src="https://github.com/user-attachments/assets/757ee4ea-c808-468a-86f4-4b062fec54de" />

This is to make sure the user knows the implications of trusting new devices.