### PR TITLE
feat: show wallet fingerprint color whenever fingerprint is shown

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/generate/mnemonic/[index].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/generate/mnemonic/[index].tsx
@@ -200,7 +200,9 @@ export default function GenerateMnemonic() {
             <SSFormLayout.Item>
               <SSHStack justifyBetween>
                 <SSChecksumStatus valid={checksumValid} />
-                {fingerprint && <SSFingerprint withLabel fingerprint={fingerprint} />}
+                {fingerprint && (
+                  <SSFingerprint withLabel fingerprint={fingerprint} />
+                )}
               </SSHStack>
             </SSFormLayout.Item>
           </SSFormLayout>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/generate/mnemonic/[index].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/generate/mnemonic/[index].tsx
@@ -200,7 +200,7 @@ export default function GenerateMnemonic() {
             <SSFormLayout.Item>
               <SSHStack justifyBetween>
                 <SSChecksumStatus valid={checksumValid} />
-                {fingerprint && <SSFingerprint value={fingerprint} />}
+                {fingerprint && <SSFingerprint withLabel fingerprint={fingerprint} />}
               </SSHStack>
             </SSFormLayout.Item>
           </SSFormLayout>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/mnemonic/[keyIndex].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/mnemonic/[keyIndex].tsx
@@ -21,6 +21,7 @@ import { type ImportMnemonicSearchParams } from '@/types/navigation/searchParams
 import { getExtendedPublicKeyFromMnemonic } from '@/utils/bip39'
 import { appNetworkToBdkNetwork } from '@/utils/bitcoin'
 import { getScriptVersionDisplayName } from '@/utils/scripts'
+import SSFingerprint from '@/components/SSFingerprint'
 
 export default function ImportMnemonic() {
   const { keyIndex } = useLocalSearchParams<ImportMnemonicSearchParams>()
@@ -218,9 +219,7 @@ export default function ImportMnemonic() {
               <SSText style={{ color: Colors.gray[500] }}>
                 {t('account.fingerprint')}
               </SSText>
-              <SSText size="md" color="muted">
-                {fingerprint}
-              </SSText>
+              <SSFingerprint fingerprint={fingerprint} />
             </SSVStack>
           </SSHStack>
           <SSSeparator />

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/mnemonic/[keyIndex].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/mnemonic/[keyIndex].tsx
@@ -4,6 +4,7 @@ import { ScrollView } from 'react-native'
 import { toast } from 'sonner-native'
 import { useShallow } from 'zustand/react/shallow'
 
+import SSFingerprint from '@/components/SSFingerprint'
 import SSGradientModal from '@/components/SSGradientModal'
 import SSKeyboardWordSelector from '@/components/SSKeyboardWordSelector'
 import SSSeedWordsInput from '@/components/SSSeedWordsInput'
@@ -21,7 +22,6 @@ import { type ImportMnemonicSearchParams } from '@/types/navigation/searchParams
 import { getExtendedPublicKeyFromMnemonic } from '@/utils/bip39'
 import { appNetworkToBdkNetwork } from '@/utils/bitcoin'
 import { getScriptVersionDisplayName } from '@/utils/scripts'
-import SSFingerprint from '@/components/SSFingerprint'
 
 export default function ImportMnemonic() {
   const { keyIndex } = useLocalSearchParams<ImportMnemonicSearchParams>()

--- a/apps/mobile/components/SSAccountCard.tsx
+++ b/apps/mobile/components/SSAccountCard.tsx
@@ -24,6 +24,7 @@ import { SSIconChevronRight, SSIconEyeOn } from './icons'
 import SSIconSync from './icons/SSIconSync'
 import SSStyledSatText from './SSStyledSatText'
 import SSText from './SSText'
+import SSFingerprint from './SSFingerprint'
 
 type SSAccountCardProps = {
   account: Account
@@ -174,12 +175,7 @@ function SSAccountCard({ account, onPress }: SSAccountCardProps) {
       <SSHStack justifyBetween style={{ position: 'relative' }}>
         <SSVStack gap={platform === 'android' ? 'none' : 'xxs'}>
           {account.keys[0].creationType === 'importAddress' ? null : (
-            <SSText
-              size="xs"
-              style={{ color: Colors.gray[500], lineHeight: 10 }}
-            >
-              {fingerprint || '-'}
-            </SSText>
+            <SSFingerprint fingerprint={fingerprint} />
           )}
           <SSHStack gap="sm">
             <SSText size="lg" color="muted">

--- a/apps/mobile/components/SSAccountCard.tsx
+++ b/apps/mobile/components/SSAccountCard.tsx
@@ -22,9 +22,9 @@ import { formatNumber } from '@/utils/format'
 
 import { SSIconChevronRight, SSIconEyeOn } from './icons'
 import SSIconSync from './icons/SSIconSync'
+import SSFingerprint from './SSFingerprint'
 import SSStyledSatText from './SSStyledSatText'
 import SSText from './SSText'
-import SSFingerprint from './SSFingerprint'
 
 type SSAccountCardProps = {
   account: Account

--- a/apps/mobile/components/SSFingerprint.tsx
+++ b/apps/mobile/components/SSFingerprint.tsx
@@ -1,22 +1,48 @@
+import { SSIconCircle } from '@/components/icons'
 import SSHStack from '@/layouts/SSHStack'
+import { Sizes, Colors, type TextFontSize } from '@/styles'
 import { t } from '@/locales'
-import { Colors } from '@/styles'
-
-import SSText from './SSText'
+import SSText from '@/components/SSText'
 
 type SSFingerprintProps = {
-  value: string
+  fingerprint: string
+  size?: TextFontSize
+  withLabel?: boolean
+  withColor?: boolean
 }
 
-function SSFingerprint({ value }: SSFingerprintProps) {
+export default function SSFingerprint({
+  fingerprint,
+  size = 'xs',
+  withLabel = false,
+  withColor = true,
+}: SSFingerprintProps) {
+  const sizeValue = Sizes['text']['fontSize'][size]
   return (
-    <SSHStack gap="xs">
-      <SSText style={{ color: Colors.gray[500] }}>
-        {t('bitcoin.fingerprint')}
-      </SSText>
-      <SSText color="muted">{value}</SSText>
+    <SSHStack gap="sm" style={{ alignItems: 'center' }}>
+      {withLabel && (
+        <SSText
+          size={size}
+          style={{ color: Colors.gray[500]}}
+        >
+          {t('bitcoin.fingerprint')}
+        </SSText>
+      )}
+      <SSHStack gap="xxs" style={{ alignItems: 'flex-start' }}>
+        {withColor && fingerprint && (
+          <SSIconCircle
+            size={sizeValue + 1}
+            fill={`#${fingerprint.slice(0, 6)}`}
+          />
+        )}
+        <SSText
+          color="muted"
+          size={size}
+          style={{ lineHeight: sizeValue }}
+        >
+          {fingerprint || '-'}
+        </SSText>
+      </SSHStack>
     </SSHStack>
   )
 }
-
-export default SSFingerprint

--- a/apps/mobile/components/SSFingerprint.tsx
+++ b/apps/mobile/components/SSFingerprint.tsx
@@ -2,10 +2,11 @@ import { SSIconCircle } from '@/components/icons'
 import SSText from '@/components/SSText'
 import SSHStack from '@/layouts/SSHStack'
 import { t } from '@/locales'
-import { Sizes, Colors, type TextFontSize } from '@/styles'
+import { Sizes, Colors } from '@/styles'
+import type { TextFontSize } from '@/styles/sizes'
 
 type SSFingerprintProps = {
-  fingerprint: string
+  fingerprint?: string
   size?: TextFontSize
   withLabel?: boolean
   withColor?: boolean

--- a/apps/mobile/components/SSFingerprint.tsx
+++ b/apps/mobile/components/SSFingerprint.tsx
@@ -1,8 +1,8 @@
 import { SSIconCircle } from '@/components/icons'
-import SSHStack from '@/layouts/SSHStack'
-import { Sizes, Colors, type TextFontSize } from '@/styles'
-import { t } from '@/locales'
 import SSText from '@/components/SSText'
+import SSHStack from '@/layouts/SSHStack'
+import { t } from '@/locales'
+import { Sizes, Colors, type TextFontSize } from '@/styles'
 
 type SSFingerprintProps = {
   fingerprint: string
@@ -15,16 +15,13 @@ export default function SSFingerprint({
   fingerprint,
   size = 'xs',
   withLabel = false,
-  withColor = true,
+  withColor = true
 }: SSFingerprintProps) {
   const sizeValue = Sizes['text']['fontSize'][size]
   return (
     <SSHStack gap="sm" style={{ alignItems: 'center' }}>
       {withLabel && (
-        <SSText
-          size={size}
-          style={{ color: Colors.gray[500]}}
-        >
+        <SSText size={size} style={{ color: Colors.gray[500] }}>
           {t('bitcoin.fingerprint')}
         </SSText>
       )}
@@ -35,11 +32,7 @@ export default function SSFingerprint({
             fill={`#${fingerprint.slice(0, 6)}`}
           />
         )}
-        <SSText
-          color="muted"
-          size={size}
-          style={{ lineHeight: sizeValue }}
-        >
+        <SSText color="muted" size={size} style={{ lineHeight: sizeValue }}>
           {fingerprint || '-'}
         </SSText>
       </SSHStack>

--- a/apps/mobile/components/SSSeedWordsInput.tsx
+++ b/apps/mobile/components/SSSeedWordsInput.tsx
@@ -499,9 +499,12 @@ export default function SSSeedWordsInput({
                   }
                 />
               )}
-              {showFingerprint &&
-                (checksumValid || electrumSeedType) &&
-                fingerprint && <SSFingerprint value={fingerprint} />}
+              {(showFingerprint && (checksumValid || electrumSeedType) && fingerprint) && (
+                <SSFingerprint
+                  fingerprint={fingerprint}
+                  withLabel
+                />
+              )}
             </SSHStack>
           </SSFormLayout.Item>
         )}

--- a/apps/mobile/components/SSSeedWordsInput.tsx
+++ b/apps/mobile/components/SSSeedWordsInput.tsx
@@ -499,12 +499,11 @@ export default function SSSeedWordsInput({
                   }
                 />
               )}
-              {(showFingerprint && (checksumValid || electrumSeedType) && fingerprint) && (
-                <SSFingerprint
-                  fingerprint={fingerprint}
-                  withLabel
-                />
-              )}
+              {showFingerprint &&
+                (checksumValid || electrumSeedType) &&
+                fingerprint && (
+                  <SSFingerprint fingerprint={fingerprint} withLabel />
+                )}
             </SSHStack>
           </SSFormLayout.Item>
         )}

--- a/apps/mobile/components/icons/SSIconCircle.tsx
+++ b/apps/mobile/components/icons/SSIconCircle.tsx
@@ -1,0 +1,22 @@
+import Svg, { Circle, type SvgProps } from 'react-native-svg'
+
+type IconProps = Pick<SvgProps, 'fill' | 'stroke'> & {
+  size: SvgProps['height']
+}
+
+export default function SSIconCircle({ size, fill, stroke }: IconProps) {
+  return (
+    <Svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill={fill}
+      stroke={stroke}
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <Circle cx="12" cy="12" r="10"/>
+    </Svg>
+  )
+}

--- a/apps/mobile/components/icons/SSIconCircle.tsx
+++ b/apps/mobile/components/icons/SSIconCircle.tsx
@@ -16,7 +16,7 @@ export default function SSIconCircle({ size, fill, stroke }: IconProps) {
       strokeLinecap="round"
       strokeLinejoin="round"
     >
-      <Circle cx="12" cy="12" r="10"/>
+      <Circle cx="12" cy="12" r="10" />
     </Svg>
   )
 }

--- a/apps/mobile/components/icons/index.tsx
+++ b/apps/mobile/components/icons/index.tsx
@@ -15,6 +15,7 @@ import SSIconChevronDown from './SSIconChevronDown'
 import SSIconChevronLeft from './SSIconChevronLeft'
 import SSIconChevronRight from './SSIconChevronRight'
 import SSIconChevronUp from './SSIconChevronUp'
+import SSIconCircle from './SSIconCircle'
 import SSIconCircleX from './SSIconCircleX'
 import SSIconCircleXThin from './SSIconCircleXThin'
 import SSIconClose from './SSIconClose'
@@ -109,6 +110,7 @@ export {
   SSIconChevronLeft,
   SSIconChevronRight,
   SSIconChevronUp,
+  SSIconCircle,
   SSIconCircleX,
   SSIconCircleXThin,
   SSIconClose,


### PR DESCRIPTION
This adds a colored circle on the left side of the fingerprint. The color of the circle is (almost) unique to the fingerprint.

-- Actually not unique because RGB colors are 6 bytes (16,77 million possible RGB values) but even the shortened fingerprint is 8 bytes. Also, 8-byte fingerprint are shortened to aid humans visualize it, because the longer version is 32-bytes.