### PR TITLE
fix: pin entry bug when input is wrong (settings>wallet>view mnemonic)

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
@@ -598,10 +598,7 @@ export default function AccountSettings() {
           setMnemonicModalVisible(true)
         }}
       />
-      <SSModal
-        visible={showPinEntry}
-        onClose={handleCloseMnemonicModal}
-      >
+      <SSModal visible={showPinEntry} onClose={handleCloseMnemonicModal}>
         <SSPinEntry
           title={t('account.enter.pin')}
           pin={pin}

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
@@ -99,12 +99,20 @@ export default function AccountSettings() {
   }
 
   function handleOnViewMnemonic() {
-    setPin(emptyPin())
     setShowPinEntry(true)
+    setPin(emptyPin())
 
     // This will auto-focus the pin input after a little delay.
     // The delay is needed because the modal has to have become visible first.
-    setTimeout(() => setPinEntryFocus(true), 200)
+    setTimeout(() => {
+      setPinEntryFocus(true)
+    }, 300)
+  }
+
+  function handleCloseMnemonicModal() {
+    setShowPinEntry(false)
+    setPin(emptyPin())
+    setPinEntryFocus(false)
   }
 
   async function handlePinEntry(pinString: string) {
@@ -120,6 +128,9 @@ export default function AccountSettings() {
     if (isPinValid) {
       setShowPinEntry(false)
       setMnemonicModalVisible(true)
+      setTimeout(() => setPin(emptyPin()), 500)
+    } else {
+      setPin(emptyPin())
     }
   }
 
@@ -587,7 +598,10 @@ export default function AccountSettings() {
           setMnemonicModalVisible(true)
         }}
       />
-      <SSModal visible={showPinEntry} onClose={() => setShowPinEntry(false)}>
+      <SSModal
+        visible={showPinEntry}
+        onClose={handleCloseMnemonicModal}
+      >
         <SSPinEntry
           title={t('account.enter.pin')}
           pin={pin}

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -40,6 +40,12 @@ function SSPinInput({
     resetFocusOnClear()
   }, [pin])
 
+  useEffect(() => {
+    if (autoFocus && currentIndex === 0) {
+      inputRefs.current[0]?.focus()
+    }
+  }, [autoFocus, currentIndex])
+
   function handleOnChangeText(text: string, index: number) {
     if (text !== '' && !ALLOWED_KEYS.includes(text)) {
       return


### PR DESCRIPTION
- the wrong input is not cleared
- need to manually focus input again
- need to manually delete wrong pin