### PR TITLE
Add mocks for react-native-nitro-sqlite and update jest config

### DIFF
--- a/apps/mobile/__mocks__/react-native-nitro-sqlite-DatabaseQueue.ts
+++ b/apps/mobile/__mocks__/react-native-nitro-sqlite-DatabaseQueue.ts
@@ -1,0 +1,1 @@
+export function closeDatabaseQueue(_name: string): void {}

--- a/apps/mobile/__mocks__/react-native-nitro-sqlite.ts
+++ b/apps/mobile/__mocks__/react-native-nitro-sqlite.ts
@@ -1,0 +1,14 @@
+export type NitroSQLiteConnection = {
+  close: () => void
+  execute: (
+    sql: string,
+    params?: unknown[]
+  ) => { insertId?: number; results: unknown[] }
+}
+
+export function open(_opts: { name: string }): NitroSQLiteConnection {
+  return {
+    close: jest.fn(),
+    execute: jest.fn().mockReturnValue({ results: [] })
+  }
+}

--- a/apps/mobile/jest.config.js
+++ b/apps/mobile/jest.config.js
@@ -25,6 +25,10 @@ const TRANSFORM_PACKAGES = [
 
 const config = {
   moduleNameMapper: {
+    '^react-native-nitro-sqlite/src/DatabaseQueue$':
+      '<rootDir>/__mocks__/react-native-nitro-sqlite-DatabaseQueue.ts',
+    '^react-native-nitro-sqlite$':
+      '<rootDir>/__mocks__/react-native-nitro-sqlite.ts',
     '^bip-321$': '<rootDir>/__mocks__/bip-321.ts',
     '^expo-secure-store$': '<rootDir>/__mocks__/expo-secure-store.ts',
     '^react-native-bdk-sdk$': '<rootDir>/__mocks__/react-native-bdk-sdk.ts',

--- a/apps/mobile/tests/unit/api/nostr.test.ts
+++ b/apps/mobile/tests/unit/api/nostr.test.ts
@@ -67,8 +67,11 @@ describe('nostrAPI', () => {
   })
 
   describe('testNostrRelaysReachable', () => {
-    it('returns false when relay list is empty', async () => {
-      await expect(testNostrRelaysReachable([])).resolves.toBe(false)
+    it('returns disconnected with no_relays when relay list is empty', async () => {
+      await expect(testNostrRelaysReachable([])).resolves.toStrictEqual({
+        reason: 'no_relays',
+        status: 'disconnected'
+      })
     })
   })
 })


### PR DESCRIPTION
- Introduced mock implementations for react-native-nitro-sqlite, including DatabaseQueue and connection handling.
- Updated jest.config.js to map react-native-nitro-sqlite imports to their respective mock files.
- Modified nostr test to reflect changes in expected output when relay list is empty.