### PR TITLE
fix Flash of previous page after closing "wallet created" modal

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/created/[id].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/created/[id].tsx
@@ -13,7 +13,7 @@ import { Colors } from '@/styles'
 import { Account } from '@/types/models/Account'
 import { getScriptVersionDisplayName } from '@/utils/scripts'
 
-export function WalletCreated() {
+export default function WalletCreated() {
   const { id } = useLocalSearchParams<{ id: Account['id'] }>()
   const account = useAccountsStore((state) =>
     state.accounts.find((_account) => _account.id === id)
@@ -37,7 +37,7 @@ export function WalletCreated() {
           <SSVStack style={{ marginVertical: 32, width: '100%' }}>
             <SSVStack itemsCenter gap="xs">
               <SSText color="white" size="2xl">
-                {name}
+                {account.name}
               </SSText>
               <SSText color="muted" size="lg">
                 {t('account.added')}
@@ -79,7 +79,7 @@ export function WalletCreated() {
           </SSVStack>
         )}
         <SSButton
-          label={t('common.ok')}
+          label={t('account.multisig.gotoWallet')}
           onPress={handleDissmisAccountAdded}
           variant="secondary"
         />

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/created/[id].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/created/[id].tsx
@@ -1,0 +1,89 @@
+import { router, Stack, useLocalSearchParams } from 'expo-router'
+
+import SSButton from '@/components/SSButton'
+import SSFingerprint from '@/components/SSFingerprint'
+import SSSeparator from '@/components/SSSeparator'
+import SSText from '@/components/SSText'
+import SSHStack from '@/layouts/SSHStack'
+import SSMainLayout from '@/layouts/SSMainLayout'
+import SSVStack from '@/layouts/SSVStack'
+import { t } from '@/locales'
+import { useAccountsStore } from '@/store/accounts'
+import { Colors } from '@/styles'
+import { Account } from '@/types/models/Account'
+import { getScriptVersionDisplayName } from '@/utils/scripts'
+
+export function WalletCreated() {
+  const { id } = useLocalSearchParams<{ id: Account['id'] }>()
+  const account = useAccountsStore((state) =>
+    state.accounts.find((_account) => _account.id === id)
+  )
+  const key = account?.keys[0]
+
+  function handleDissmisAccountAdded() {
+    router.dismissAll()
+    router.navigate(`/signer/bitcoin/account/${id}`)
+  }
+
+  return (
+    <SSMainLayout>
+      <Stack.Screen
+        options={{
+          headerTitle: () => <SSText uppercase>{account?.name}</SSText>
+        }}
+      />
+      <SSVStack>
+        {key && (
+          <SSVStack style={{ marginVertical: 32, width: '100%' }}>
+            <SSVStack itemsCenter gap="xs">
+              <SSText color="white" size="2xl">
+                {name}
+              </SSText>
+              <SSText color="muted" size="lg">
+                {t('account.added')}
+              </SSText>
+            </SSVStack>
+            <SSSeparator />
+            <SSHStack justifyEvenly style={{ alignItems: 'flex-start' }}>
+              <SSVStack itemsCenter>
+                <SSText style={{ color: Colors.gray[500] }}>
+                  {t('account.script')}
+                </SSText>
+                <SSText size="md" color="muted" center>
+                  {key.scriptVersion
+                    ? getScriptVersionDisplayName(key.scriptVersion)
+                    : '-'}
+                </SSText>
+              </SSVStack>
+              <SSVStack itemsCenter>
+                <SSText style={{ color: Colors.gray[500] }}>
+                  {t('account.fingerprint')}
+                </SSText>
+                <SSFingerprint fingerprint={key.fingerprint} />
+              </SSVStack>
+            </SSHStack>
+            <SSSeparator />
+            <SSVStack itemsCenter>
+              <SSText style={{ color: Colors.gray[500] }}>
+                {t('account.derivationPath')}
+              </SSText>
+              <SSText size="md" color="muted">
+                {key.derivationPath || '-'}
+              </SSText>
+            </SSVStack>
+          </SSVStack>
+        )}
+        {!key && (
+          <SSVStack>
+            <SSText>Account creation failed.</SSText>
+          </SSVStack>
+        )}
+        <SSButton
+          label={t('common.ok')}
+          onPress={handleDissmisAccountAdded}
+          variant="secondary"
+        />
+      </SSVStack>
+    </SSMainLayout>
+  )
+}

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/mnemonic/[keyIndex].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/mnemonic/[keyIndex].tsx
@@ -4,35 +4,26 @@ import { ScrollView } from 'react-native'
 import { toast } from 'sonner-native'
 import { useShallow } from 'zustand/react/shallow'
 
-import SSFingerprint from '@/components/SSFingerprint'
-import SSGradientModal from '@/components/SSGradientModal'
 import SSKeyboardWordSelector from '@/components/SSKeyboardWordSelector'
 import SSSeedWordsInput from '@/components/SSSeedWordsInput'
-import SSSeparator from '@/components/SSSeparator'
 import SSText from '@/components/SSText'
 import useAccountBuilderFinish from '@/hooks/useAccountBuilderFinish'
-import SSHStack from '@/layouts/SSHStack'
 import SSMainLayout from '@/layouts/SSMainLayout'
-import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { useAccountBuilderStore } from '@/store/accountBuilder'
 import { useBlockchainStore } from '@/store/blockchain'
-import { Colors } from '@/styles'
 import { type ImportMnemonicSearchParams } from '@/types/navigation/searchParams'
 import { getExtendedPublicKeyFromMnemonic } from '@/utils/bip39'
 import { appNetworkToBdkNetwork } from '@/utils/bitcoin'
-import { getScriptVersionDisplayName } from '@/utils/scripts'
 
 export default function ImportMnemonic() {
   const { keyIndex } = useLocalSearchParams<ImportMnemonicSearchParams>()
   const router = useRouter()
   const [
     name,
-    keys,
     scriptVersion,
     mnemonicWordCount,
     mnemonicWordList,
-    fingerprint,
     policyType,
     clearAccount,
     setMnemonic,
@@ -45,11 +36,9 @@ export default function ImportMnemonic() {
   ] = useAccountBuilderStore(
     useShallow((state) => [
       state.name,
-      state.keys,
       state.scriptVersion,
       state.mnemonicWordCount,
       state.mnemonicWordList,
-      state.fingerprint,
       state.policyType,
       state.clearAccount,
       state.setMnemonic,
@@ -63,13 +52,8 @@ export default function ImportMnemonic() {
   )
   const network = useBlockchainStore((state) => state.selectedNetwork)
   const { accountBuilderFinish } = useAccountBuilderFinish()
-
-  const [createdAccountId, setCreatedAccountId] = useState<string>()
   const [currentMnemonic, setCurrentMnemonic] = useState('')
   const [currentFingerprint, setCurrentFingerprint] = useState('')
-
-  const [accountAddedModalVisible, setAccountAddedModalVisible] =
-    useState(false)
 
   const [wordSelectorState, setWordSelectorState] = useState({
     onWordSelected: () => {
@@ -103,8 +87,9 @@ export default function ImportMnemonic() {
         return
       }
 
-      setCreatedAccountId(data.accountWithEncryptedSecret.id)
-      setAccountAddedModalVisible(true)
+      const createdAccountId = data.accountWithEncryptedSecret.id
+      clearAccount()
+      router.navigate(`/signer/bitcoin/account/add/created/${createdAccountId}`)
     } catch (error) {
       toast.error((error as Error).message || t('account.import.error.generic'))
     }
@@ -128,16 +113,6 @@ export default function ImportMnemonic() {
     clearKeyState()
     toast.success('Key imported successfully')
     router.back()
-  }
-
-  function handleOnCloseAccountAddedModal() {
-    setAccountAddedModalVisible(false)
-
-    if (createdAccountId) {
-      clearAccount()
-      router.dismissAll()
-      router.navigate(`/signer/bitcoin/account/${createdAccountId}`)
-    }
   }
 
   function handleOnPressCancel() {
@@ -190,48 +165,6 @@ export default function ImportMnemonic() {
         wordListName={mnemonicWordList}
         onWordSelected={wordSelectorState.onWordSelected}
       />
-      <SSGradientModal
-        visible={accountAddedModalVisible}
-        closeText={t('account.gotoWallet')}
-        onClose={() => handleOnCloseAccountAddedModal()}
-      >
-        <SSVStack style={{ marginVertical: 32, width: '100%' }}>
-          <SSVStack itemsCenter gap="xs">
-            <SSText color="white" size="2xl">
-              {name}
-            </SSText>
-            <SSText color="muted" size="lg">
-              {t('account.added')}
-            </SSText>
-          </SSVStack>
-          <SSSeparator />
-          <SSHStack justifyEvenly style={{ alignItems: 'flex-start' }}>
-            <SSVStack itemsCenter>
-              <SSText style={{ color: Colors.gray[500] }}>
-                {t('account.script')}
-              </SSText>
-              <SSText size="md" color="muted" center>
-                {getScriptVersionDisplayName(scriptVersion)}
-              </SSText>
-            </SSVStack>
-            <SSVStack itemsCenter>
-              <SSText style={{ color: Colors.gray[500] }}>
-                {t('account.fingerprint')}
-              </SSText>
-              <SSFingerprint fingerprint={fingerprint} />
-            </SSVStack>
-          </SSHStack>
-          <SSSeparator />
-          <SSVStack itemsCenter>
-            <SSText style={{ color: Colors.gray[500] }}>
-              {t('account.derivationPath')}
-            </SSText>
-            <SSText size="md" color="muted">
-              {keys[Number(keyIndex)]?.derivationPath || '-'}
-            </SSText>
-          </SSVStack>
-        </SSVStack>
-      </SSGradientModal>
     </SSMainLayout>
   )
 }

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/mnemonic/[keyIndex].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/mnemonic/[keyIndex].tsx
@@ -88,8 +88,10 @@ export default function ImportMnemonic() {
       }
 
       const createdAccountId = data.accountWithEncryptedSecret.id
-      clearAccount()
       router.navigate(`/signer/bitcoin/account/add/created/${createdAccountId}`)
+
+      // we clear the account in the background to avoid an immediate re-render of the current page which resets its state variables
+      setTimeout(clearAccount, 1500)
     } catch (error) {
       toast.error((error as Error).message || t('account.import.error.generic'))
     }


### PR DESCRIPTION
# Flash of previous page after closing "wallet created" modal

On the seed-word import flow, tapping "Go to wallet" in the created-wallet modal
briefly shows the import screen (or an earlier wizard step) before the wallet
page animates in.

## Root cause

Close handler does **two-step navigation** instead of one:

```tsx
function handleOnCloseAccountAddedModal() {
  setAccountAddedModalVisible(false) // 1. fade modal out
  if (createdAccountId) {
    clearAccount()
    router.dismissAll()               // 2. pop wizard stack → tab root (animated)
    router.navigate(`/signer/bitcoin/account/${createdAccountId}`) // 3. push wallet
  }
}
```

what user sees:

1. `SSGradientModal` fades out, underlying import screen is revealed.
2. `router.dismissAll()` plays the pop-back animation, revealing the tab/home screen underneath the wizard.
3. `router.navigate(...)` pushes the wallet screen with its own slide-in animation.

## Fix

Move the modal to its own page. When the user press "go to wallet" on this new page, no splash is seen.