### PR TITLE
Prevent creating account with duplicate

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
@@ -14,7 +14,7 @@ import SSPinEntry from '@/components/SSPinEntry'
 import SSSeedQR from '@/components/SSSeedQR'
 import SSSignatureRequiredDisplay from '@/components/SSSignatureRequiredDisplay'
 import SSText from '@/components/SSText'
-import SSTextInput from '@/components/SSTextInput'
+import SSTextInput, { SSTextInputProps } from '@/components/SSTextInput'
 import { PIN_KEY, SALT_KEY } from '@/config/auth'
 import SSFormLayout from '@/layouts/SSFormLayout'
 import SSHStack from '@/layouts/SSHStack'
@@ -41,13 +41,14 @@ export default function AccountSettings() {
   const { id: currentAccountId } = useLocalSearchParams<AccountSearchParams>()
   const insets = useSafeAreaInsets()
 
-  const [account, updateAccountName, deleteAccount] = useAccountsStore(
+  const [accounts, updateAccountName, deleteAccount] = useAccountsStore(
     useShallow((state) => [
-      state.accounts.find((_account) => _account.id === currentAccountId),
+      state.accounts,
       state.updateAccountName,
       state.deleteAccount
     ])
   )
+  const account = accounts.find((_account) => _account.id === currentAccountId)
   const removeAccountWallet = useWalletsStore(
     (state) => state.removeAccountWallet
   )
@@ -61,9 +62,9 @@ export default function AccountSettings() {
   const [accountName, setAccountName] = useState<Account['name']>(
     account?.name || ''
   )
+  const [isValidName, setIsValidName] = useState<SSTextInputProps['status']>('valid')
   const [localMnemonic, setLocalMnemonic] = useState('')
   const [decryptedKeys, setDecryptedKeys] = useState<Key[]>([])
-
   const [deleteModalVisible, setDeleteModalVisible] = useState(false)
   const [mnemonicModalVisible, setMnemonicModalVisible] = useState(false)
   const [seedQRModalVisible, setSeedQRModalVisible] = useState(false)
@@ -85,6 +86,25 @@ export default function AccountSettings() {
       labeled: labels.filter((l) => l.type === 'output').length,
       total: account?.utxos?.length || 0
     }
+  }
+
+  function validateName(name: string) {
+    if (name === '') {
+      setIsValidName(undefined)
+      return
+    }
+    const invalid = accounts.some(
+      (otherAccount) =>
+        otherAccount.id !== currentAccountId &&
+        otherAccount.name === name &&
+        otherAccount.network === account?.network
+    )
+    setIsValidName(invalid ? 'invalid' : 'valid')
+  }
+
+  function handleSetAccountName(name: string) {
+    validateName(name)
+    setAccountName(name)
   }
 
   function getPolicyTypeButtonLabel() {
@@ -238,7 +258,10 @@ export default function AccountSettings() {
         <SSFormLayout>
           <SSFormLayout.Item>
             <SSFormLayout.Label label={t('account.name')} />
-            <SSTextInput value={accountName} onChangeText={setAccountName} />
+            <SSTextInput
+              value={accountName}
+              onChangeText={handleSetAccountName}
+            />
           </SSFormLayout.Item>
         </SSFormLayout>
         <SSVStack gap="xs" style={styles.infoTable}>
@@ -440,6 +463,7 @@ export default function AccountSettings() {
           <SSButton
             label={t('common.save')}
             variant="secondary"
+            disabled={isValidName !== 'valid'}
             onPress={saveChanges}
           />
         </SSVStack>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
@@ -123,12 +123,6 @@ export default function AccountSettings() {
   function handleOnViewMnemonic() {
     setShowPinEntry(true)
     setPin(emptyPin())
-
-    // This will auto-focus the pin input after a little delay.
-    // The delay is needed because the modal has to have become visible first.
-    setTimeout(() => {
-      setPinEntryFocus(true)
-    }, 300)
   }
 
   function handleCloseMnemonicModal() {

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
@@ -62,7 +62,8 @@ export default function AccountSettings() {
   const [accountName, setAccountName] = useState<Account['name']>(
     account?.name || ''
   )
-  const [isValidName, setIsValidName] = useState<SSTextInputProps['status']>('valid')
+  const [isValidName, setIsValidName] = useState<SSTextInputProps['status']>()
+  const [isPseudoDuplicatedName, setIsPseudoDuplicatedName] = useState(false) // pseudo-duplicate name = wallet of other network has same name
   const [localMnemonic, setLocalMnemonic] = useState('')
   const [decryptedKeys, setDecryptedKeys] = useState<Key[]>([])
   const [deleteModalVisible, setDeleteModalVisible] = useState(false)
@@ -100,6 +101,11 @@ export default function AccountSettings() {
         otherAccount.network === account?.network
     )
     setIsValidName(invalid ? 'invalid' : 'valid')
+    const pseudoDuplicate = accounts.some(
+      (otherAccount) =>
+        otherAccount.network !== account?.network && otherAccount.name === name
+    )
+    setIsPseudoDuplicatedName(pseudoDuplicate)
   }
 
   function handleSetAccountName(name: string) {
@@ -255,6 +261,17 @@ export default function AccountSettings() {
             <SSTextInput
               value={accountName}
               onChangeText={handleSetAccountName}
+              status={isValidName}
+              error={
+                isValidName === 'invalid'
+                  ? t('account.error.nameDuplicated')
+                  : ''
+              }
+              warning={
+                isPseudoDuplicatedName
+                  ? t('account.error.namePseudoDuplicated')
+                  : ''
+              }
             />
           </SSFormLayout.Item>
         </SSFormLayout>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
@@ -14,8 +14,9 @@ import SSPinEntry from '@/components/SSPinEntry'
 import SSSeedQR from '@/components/SSSeedQR'
 import SSSignatureRequiredDisplay from '@/components/SSSignatureRequiredDisplay'
 import SSText from '@/components/SSText'
-import SSTextInput, { SSTextInputProps } from '@/components/SSTextInput'
+import SSTextInput from '@/components/SSTextInput'
 import { PIN_KEY, SALT_KEY } from '@/config/auth'
+import useAccountNameValidation from '@/hooks/useAccountNameValidation'
 import SSFormLayout from '@/layouts/SSFormLayout'
 import SSHStack from '@/layouts/SSHStack'
 import SSSeedLayout from '@/layouts/SSSeedLayout'
@@ -25,7 +26,7 @@ import { getItem, getKeySecret } from '@/storage/encrypted'
 import { useAccountsStore } from '@/store/accounts'
 import { useWalletsStore } from '@/store/wallets'
 import { Colors } from '@/styles'
-import { type Account, type Key, type Secret } from '@/types/models/Account'
+import { type Key, type Secret } from '@/types/models/Account'
 import { type AccountSearchParams } from '@/types/navigation/searchParams'
 import {
   decryptAllAccountKeySecrets,
@@ -56,14 +57,6 @@ export default function AccountSettings() {
   const [scriptVersion, setScriptVersion] = useState<Key['scriptVersion']>(
     account?.keys[0]?.scriptVersion || 'P2WPKH'
   )
-  const [network, setNetwork] = useState<NonNullable<string>>(
-    account?.network || 'signet'
-  )
-  const [accountName, setAccountName] = useState<Account['name']>(
-    account?.name || ''
-  )
-  const [isValidName, setIsValidName] = useState<SSTextInputProps['status']>()
-  const [isPseudoDuplicatedName, setIsPseudoDuplicatedName] = useState(false) // pseudo-duplicate name = wallet of other network has same name
   const [localMnemonic, setLocalMnemonic] = useState('')
   const [decryptedKeys, setDecryptedKeys] = useState<Key[]>([])
   const [deleteModalVisible, setDeleteModalVisible] = useState(false)
@@ -89,29 +82,15 @@ export default function AccountSettings() {
     }
   }
 
-  function validateName(name: string) {
-    if (name === '') {
-      setIsValidName(undefined)
-      return
-    }
-    const invalid = accounts.some(
-      (otherAccount) =>
-        otherAccount.id !== currentAccountId &&
-        otherAccount.name === name &&
-        otherAccount.network === account?.network
-    )
-    setIsValidName(invalid ? 'invalid' : 'valid')
-    const pseudoDuplicate = accounts.some(
-      (otherAccount) =>
-        otherAccount.network !== account?.network && otherAccount.name === name
-    )
-    setIsPseudoDuplicatedName(pseudoDuplicate)
-  }
-
-  function handleSetAccountName(name: string) {
-    validateName(name)
-    setAccountName(name)
-  }
+  const {
+    localAccountName,
+    isValidName,
+    isPseudoDuplicatedName,
+    handleSetAccountName
+  } = useAccountNameValidation({
+    name: account?.name,
+    network: account?.network
+  })
 
   function getPolicyTypeButtonLabel() {
     switch (account?.policyType) {
@@ -158,7 +137,7 @@ export default function AccountSettings() {
   }
 
   function saveChanges() {
-    updateAccountName(currentAccountId!, accountName)
+    updateAccountName(currentAccountId!, localAccountName)
     router.replace(`/signer/bitcoin/account/${currentAccountId}/`)
   }
 
@@ -259,7 +238,7 @@ export default function AccountSettings() {
           <SSFormLayout.Item>
             <SSFormLayout.Label label={t('account.name')} />
             <SSTextInput
-              value={accountName}
+              value={localAccountName}
               onChangeText={handleSetAccountName}
               status={isValidName}
               error={

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/index.tsx
@@ -195,13 +195,6 @@ export default function AccountSettings() {
     }
   }, [account])
 
-  // Update network when account changes
-  useEffect(() => {
-    if (account?.network) {
-      setNetwork(account.network)
-    }
-  }, [account?.network])
-
   // Update script version when account changes
   useEffect(() => {
     const accountKeys = account?.keys
@@ -281,7 +274,7 @@ export default function AccountSettings() {
           </SSHStack>
           <SSHStack justifyBetween>
             <SSText color="muted">{t('account.network.title')}</SSText>
-            <SSText>{network}</SSText>
+            <SSText>{account?.network || '-'}</SSText>
           </SSHStack>
           <SSHStack justifyBetween>
             <SSText color="muted">{t('account.policy.title')}</SSText>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/index.tsx
@@ -6,12 +6,14 @@ import { useShallow } from 'zustand/react/shallow'
 import SSButton from '@/components/SSButton'
 import SSCheckbox from '@/components/SSCheckbox'
 import SSText from '@/components/SSText'
-import SSTextInput from '@/components/SSTextInput'
+import SSTextInput, { type SSTextInputProps } from '@/components/SSTextInput'
 import SSFormLayout from '@/layouts/SSFormLayout'
 import SSMainLayout from '@/layouts/SSMainLayout'
 import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { useAccountBuilderStore } from '@/store/accountBuilder'
+import { useAccountsStore } from '@/store/accounts'
+import { useBlockchainStore } from '@/store/blockchain'
 import { type Account } from '@/types/models/Account'
 
 export default function Add() {
@@ -20,9 +22,32 @@ export default function Add() {
     useShallow((state) => [state.setName, state.setPolicyType])
   )
 
+  const accounts = useAccountsStore((state) => state.accounts)
+  const network = useBlockchainStore((state) => state.selectedNetwork)
+  const currentNetworkAccounts = accounts.filter(
+    (account) => account.network === network
+  )
+
   const [localName, setLocalName] = useState('')
   const [localPolicyType, setLocalPolicyType] =
     useState<NonNullable<Account['policyType']>>('singlesig')
+  const [isValidName, setIsValidName] = useState<SSTextInputProps['status']>()
+
+  function validateName(name: string) {
+    if (name === '') {
+      setIsValidName(undefined)
+    } else {
+      const isDuplicatedName = currentNetworkAccounts.some(
+        (account) => account.name === name
+      )
+      setIsValidName(isDuplicatedName ? 'invalid' : 'valid')
+    }
+  }
+
+  function handleSetName(text: string) {
+    setLocalName(text)
+    validateName(text)
+  }
 
   function handleOnPressContinue() {
     setAccountName(localName)
@@ -50,7 +75,8 @@ export default function Add() {
             <SSFormLayout.Label label={t('account.name')} />
             <SSTextInput
               value={localName}
-              onChangeText={(text) => setLocalName(text)}
+              status={isValidName}
+              onChangeText={handleSetName}
             />
           </SSFormLayout.Item>
           <View style={{ marginTop: 24 }}>
@@ -86,7 +112,7 @@ export default function Add() {
           <SSButton
             variant="secondary"
             label={t('common.continue')}
-            disabled={localName === ''}
+            disabled={localName === '' || !isValidName}
             onPress={handleOnPressContinue}
           />
           <SSButton

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/index.tsx
@@ -32,16 +32,22 @@ export default function Add() {
   const [localPolicyType, setLocalPolicyType] =
     useState<NonNullable<Account['policyType']>>('singlesig')
   const [isValidName, setIsValidName] = useState<SSTextInputProps['status']>()
+  const [isPseudoDuplicatedName, setIsPseudoDuplicatedName] = useState(false) // pseudo-duplicate name = wallet of other network has same name
 
   function validateName(name: string) {
     if (name === '') {
       setIsValidName(undefined)
-    } else {
-      const isDuplicatedName = currentNetworkAccounts.some(
-        (account) => account.name === name
-      )
-      setIsValidName(isDuplicatedName ? 'invalid' : 'valid')
+      return
     }
+    const duplicated = currentNetworkAccounts.some(
+      (account) => account.name === name
+    )
+    setIsValidName(duplicated ? 'invalid' : 'valid')
+    const pseudoDuplicated = accounts.some(
+      (otherAccount) =>
+        otherAccount.network !== network && otherAccount.name === name
+    )
+    setIsPseudoDuplicatedName(pseudoDuplicated)
   }
 
   function handleSetName(text: string) {
@@ -77,6 +83,16 @@ export default function Add() {
               value={localName}
               status={isValidName}
               onChangeText={handleSetName}
+              error={
+                isValidName === 'invalid'
+                  ? t('account.error.nameDuplicated')
+                  : ''
+              }
+              warning={
+                isPseudoDuplicatedName
+                  ? t('account.error.namePseudoDuplicated')
+                  : ''
+              }
             />
           </SSFormLayout.Item>
           <View style={{ marginTop: 24 }}>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/index.tsx
@@ -6,57 +6,35 @@ import { useShallow } from 'zustand/react/shallow'
 import SSButton from '@/components/SSButton'
 import SSCheckbox from '@/components/SSCheckbox'
 import SSText from '@/components/SSText'
-import SSTextInput, { type SSTextInputProps } from '@/components/SSTextInput'
+import SSTextInput from '@/components/SSTextInput'
+import useAccountNameValidation from '@/hooks/useAccountNameValidation'
 import SSFormLayout from '@/layouts/SSFormLayout'
 import SSMainLayout from '@/layouts/SSMainLayout'
 import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { useAccountBuilderStore } from '@/store/accountBuilder'
-import { useAccountsStore } from '@/store/accounts'
 import { useBlockchainStore } from '@/store/blockchain'
 import { type Account } from '@/types/models/Account'
 
 export default function Add() {
   const router = useRouter()
-  const [setAccountName, setAccountPolicyType] = useAccountBuilderStore(
-    useShallow((state) => [state.setName, state.setPolicyType])
-  )
-
-  const accounts = useAccountsStore((state) => state.accounts)
   const network = useBlockchainStore((state) => state.selectedNetwork)
-  const currentNetworkAccounts = accounts.filter(
-    (account) => account.network === network
+  const [name, setAccountName, setAccountPolicyType] = useAccountBuilderStore(
+    useShallow((state) => [state.name, state.setName, state.setPolicyType])
   )
 
-  const [localName, setLocalName] = useState('')
   const [localPolicyType, setLocalPolicyType] =
     useState<NonNullable<Account['policyType']>>('singlesig')
-  const [isValidName, setIsValidName] = useState<SSTextInputProps['status']>()
-  const [isPseudoDuplicatedName, setIsPseudoDuplicatedName] = useState(false) // pseudo-duplicate name = wallet of other network has same name
 
-  function validateName(name: string) {
-    if (name === '') {
-      setIsValidName(undefined)
-      return
-    }
-    const duplicated = currentNetworkAccounts.some(
-      (account) => account.name === name
-    )
-    setIsValidName(duplicated ? 'invalid' : 'valid')
-    const pseudoDuplicated = accounts.some(
-      (otherAccount) =>
-        otherAccount.network !== network && otherAccount.name === name
-    )
-    setIsPseudoDuplicatedName(pseudoDuplicated)
-  }
-
-  function handleSetName(text: string) {
-    setLocalName(text)
-    validateName(text)
-  }
+  const {
+    localAccountName,
+    isValidName,
+    isPseudoDuplicatedName,
+    handleSetAccountName
+  } = useAccountNameValidation({ name, network })
 
   function handleOnPressContinue() {
-    setAccountName(localName)
+    setAccountName(localAccountName)
     setAccountPolicyType(localPolicyType)
 
     if (localPolicyType === 'singlesig') {
@@ -80,9 +58,9 @@ export default function Add() {
           <SSFormLayout.Item>
             <SSFormLayout.Label label={t('account.name')} />
             <SSTextInput
-              value={localName}
+              value={localAccountName}
               status={isValidName}
-              onChangeText={handleSetName}
+              onChangeText={handleSetAccountName}
               error={
                 isValidName === 'invalid'
                   ? t('account.error.nameDuplicated')
@@ -128,7 +106,7 @@ export default function Add() {
           <SSButton
             variant="secondary"
             label={t('common.continue')}
-            disabled={localName === '' || !isValidName}
+            disabled={localAccountName === '' || !isValidName}
             onPress={handleOnPressContinue}
           />
           <SSButton

--- a/apps/mobile/components/SSTextInput.tsx
+++ b/apps/mobile/components/SSTextInput.tsx
@@ -1,8 +1,11 @@
 import { type ForwardedRef, forwardRef } from 'react'
 import { StyleSheet, TextInput, View } from 'react-native'
 
+import SSVStack from '@/layouts/SSVStack'
 import { Colors, Sizes } from '@/styles'
 import { descriptorValidityCache } from '@/utils/validation'
+
+import SSText from './SSText'
 
 export type SSTextInputProps = {
   variant?: 'default' | 'outline'
@@ -10,6 +13,8 @@ export type SSTextInputProps = {
   align?: 'center' | 'left'
   actionRight?: React.ReactNode
   status?: 'valid' | 'invalid'
+  warning?: string
+  error?: string
 } & React.ComponentPropsWithoutRef<typeof TextInput>
 
 function SSTextInput(
@@ -21,6 +26,8 @@ function SSTextInput(
     status,
     style,
     value,
+    error,
+    warning,
     ...props
   }: SSTextInputProps,
   ref: ForwardedRef<TextInput>
@@ -63,16 +70,30 @@ function SSTextInput(
 
   return (
     <View style={styles.containerBase}>
-      <TextInput
-        ref={ref}
-        placeholderTextColor={Colors.gray[400]}
-        autoCorrect={false}
-        spellCheck={false}
-        value={value}
-        style={textInputStyle}
-        {...props}
-      />
-      <View style={styles.actionRightBase}>{actionRight}</View>
+      <SSVStack gap="xs">
+        <View>
+          <TextInput
+            ref={ref}
+            placeholderTextColor={Colors.gray[400]}
+            autoCorrect={false}
+            spellCheck={false}
+            value={value}
+            style={textInputStyle}
+            {...props}
+          />
+          <View style={styles.actionRightBase}>{actionRight}</View>
+        </View>
+        {error && (
+          <SSText size="xs" style={{ color: Colors.error, lineHeight: 12 }}>
+            {error}
+          </SSText>
+        )}
+        {warning && (
+          <SSText size="xs" style={{ color: Colors.warning, lineHeight: 12 }}>
+            {warning}
+          </SSText>
+        )}
+      </SSVStack>
     </View>
   )
 }

--- a/apps/mobile/components/SSTextInput.tsx
+++ b/apps/mobile/components/SSTextInput.tsx
@@ -4,7 +4,7 @@ import { StyleSheet, TextInput, View } from 'react-native'
 import { Colors, Sizes } from '@/styles'
 import { descriptorValidityCache } from '@/utils/validation'
 
-type SSTextInputProps = {
+export type SSTextInputProps = {
   variant?: 'default' | 'outline'
   size?: 'default' | 'small'
   align?: 'center' | 'left'

--- a/apps/mobile/hooks/useAccountNameValidation.ts
+++ b/apps/mobile/hooks/useAccountNameValidation.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react'
+
+import { SSTextInputProps } from '@/components/SSTextInput'
+import { useAccountsStore } from '@/store/accounts'
+import { Account } from '@/types/models/Account'
+
+type AccountNameValidationParams = {
+  name?: Account['name']
+  network?: Account['network']
+}
+
+function useAccountNameValidation({
+  name = '',
+  network = 'bitcoin'
+}: AccountNameValidationParams) {
+  const accounts = useAccountsStore((state) => state.accounts)
+  const currentNetworkAccounts = accounts.filter(
+    (account) => account.network === network
+  )
+
+  const [localAccountName, setLocalAccountName] = useState(name)
+  const [isValidName, setIsValidName] = useState<SSTextInputProps['status']>()
+  const [isPseudoDuplicatedName, setIsPseudoDuplicatedName] = useState(false) // pseudo-duplicate name = wallet of other network has same name
+
+  function validateName(name: string) {
+    if (name === '') {
+      setIsValidName(undefined)
+      return
+    }
+    const duplicated = currentNetworkAccounts.some(
+      (account: Account) => account.name === name
+    )
+    setIsValidName(duplicated ? 'invalid' : 'valid')
+    const pseudoDuplicated = accounts.some(
+      (otherAccount: Account) =>
+        otherAccount.network !== network && otherAccount.name === name
+    )
+    setIsPseudoDuplicatedName(pseudoDuplicated)
+  }
+
+  function handleSetAccountName(text: string) {
+    setLocalAccountName(text)
+    validateName(text)
+  }
+
+  return {
+    handleSetAccountName,
+    isPseudoDuplicatedName,
+    isValidName,
+    localAccountName
+  }
+}
+
+export default useAccountNameValidation

--- a/apps/mobile/locales/en.json
+++ b/apps/mobile/locales/en.json
@@ -39,6 +39,8 @@
     "entropy.drawing.label": "Drawing",
     "entropy.none.label": "None",
     "entropy.title": "Extra Entropy",
+    "error.nameDuplicated": "A wallet with this name already exists.",
+    "error.namePseudoDuplicated": "A wallet of another network has the same name.",
     "export.config": "Export config",
     "export.descriptors": "Descriptors",
     "export.descriptorsPDF": "Export as PDF",


### PR DESCRIPTION
This pull request:

- [x] prevent creating wallets with same names
- [x] prevent editing the name of an existing wallet to be the name of another existing wallet
- [x] allow duplicate names for wallets of distinct networks (i.e, two wallets name "My Wallet", one is mainnet and another is testnet)
- [x] show feedback warning message to user upon all scenarios describe above
- [x] test it works on both single sig and mult-sig wallets

Solves #369.