### PR TITLE
Fixes and Improvements

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/ioPreview.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/ioPreview.tsx
@@ -196,7 +196,7 @@ export default function IOPreview() {
     () => utxosValue(account.utxos),
     [account.utxos]
   )
-  const utxosSelectedValue = utxosValue(getInputs())
+  const utxosSelectedValue = utxosValue(Array.from(inputs.values()))
 
   // First calculate without change output
   const baseTransactionSize = useMemo(() => {

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/ioPreview.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/ioPreview.tsx
@@ -11,6 +11,7 @@ import {
   View
 } from 'react-native'
 import { KeychainKind } from 'react-native-bdk-sdk'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { toast } from 'sonner-native'
 import { useShallow } from 'zustand/react/shallow'
 
@@ -73,6 +74,7 @@ export default function IOPreview() {
     AccountSearchParams & { dustWarning?: string }
   >()
   const isFocused = useIsFocused()
+  const insets = useSafeAreaInsets()
 
   const account = useAccountsStore(
     (state) => state.accounts.find((account) => account.id === id)!
@@ -913,7 +915,7 @@ export default function IOPreview() {
           bottom: 0,
           flexDirection: 'row',
           justifyContent: 'center',
-          paddingBottom: 20,
+          paddingBottom: 20 + insets.bottom,
           position: 'absolute',
           width: '100%'
         }}

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/selectUtxoBubbles.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/selectUtxoBubbles.tsx
@@ -37,13 +37,8 @@ function SelectUtxoBubbles() {
     useShallow((state) => [state.currencyUnit, state.useZeroPadding])
   )
   const zeroPadding = useZeroPadding || currencyUnit === 'btc'
-  const [inputs, getInputs, addInput, removeInput] = useTransactionBuilderStore(
-    useShallow((state) => [
-      state.inputs,
-      state.getInputs,
-      state.addInput,
-      state.removeInput
-    ])
+  const [inputs, addInput, removeInput] = useTransactionBuilderStore(
+    useShallow((state) => [state.inputs, state.addInput, state.removeInput])
   )
   const [fiatCurrency, satsToFiat] = usePriceStore(
     useShallow((state) => [state.fiatCurrency, state.satsToFiat])
@@ -65,7 +60,7 @@ function SelectUtxoBubbles() {
   }
 
   const utxosTotalValue = utxosValue(account.utxos)
-  const utxosSelectedValue = utxosValue(getInputs())
+  const utxosSelectedValue = utxosValue(Array.from(inputs.values()))
 
   function handleOnToggleSelected(utxo: Utxo) {
     const includesInput = inputs.has(getUtxoOutpoint(utxo))

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/selectUtxoBubbles.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/selectUtxoBubbles.tsx
@@ -3,6 +3,7 @@ import { LinearGradient } from 'expo-linear-gradient'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useState } from 'react'
 import { StyleSheet, useWindowDimensions, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useShallow } from 'zustand/react/shallow'
 
 import { SSIconList } from '@/components/icons'
@@ -27,6 +28,7 @@ import { getUtxoOutpoint } from '@/utils/utxo'
 function SelectUtxoBubbles() {
   const router = useRouter()
   const { id } = useLocalSearchParams<AccountSearchParams>()
+  const insets = useSafeAreaInsets()
 
   const account = useAccountsStore(
     (state) => state.accounts.find((account) => account.id === id)!
@@ -173,7 +175,10 @@ function SelectUtxoBubbles() {
       />
       <LinearGradient
         locations={[0, 0.1255, 0.2678, 1]}
-        style={styles.absoluteSubmitContainer}
+        style={[
+          styles.absoluteSubmitContainer,
+          { paddingBottom: 20 + insets.bottom }
+        ]}
         colors={['#0A0A0A00', '#0A0A0A0F', '#0A0A0A2A', '#0A0A0A']}
       >
         <SSVStack style={{ width: '92%' }}>
@@ -238,7 +243,6 @@ const styles = StyleSheet.create({
     bottom: 0,
     flexDirection: 'row',
     justifyContent: 'center',
-    paddingBottom: 20,
     paddingHorizontal: 0,
     paddingTop: 0,
     position: 'absolute',

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/selectUtxoList.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/selectUtxoList.tsx
@@ -42,16 +42,14 @@ export default function SelectUtxoList() {
     useShallow((state) => [state.currencyUnit, state.useZeroPadding])
   )
   const zeroPadding = useZeroPadding || currencyUnit === 'btc'
-  const [inputs, getInputs, hasInput, addInput, removeInput] =
-    useTransactionBuilderStore(
-      useShallow((state) => [
-        state.inputs,
-        state.getInputs,
-        state.hasInput,
-        state.addInput,
-        state.removeInput
-      ])
-    )
+  const [inputs, hasInput, addInput, removeInput] = useTransactionBuilderStore(
+    useShallow((state) => [
+      state.inputs,
+      state.hasInput,
+      state.addInput,
+      state.removeInput
+    ])
+  )
 
   const utxoOutpointSet = new Set(account.utxos.map(getUtxoOutpoint))
   const orphanedInputs = Array.from(inputs.values()).filter(
@@ -96,7 +94,7 @@ export default function SelectUtxoList() {
     () => utxosValue(account.utxos),
     [account.utxos]
   )
-  const utxosSelectedValue = utxosValue(getInputs())
+  const utxosSelectedValue = utxosValue(Array.from(inputs.values()))
 
   function handleSelectAllUtxos() {
     for (const utxo of account.utxos) {

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/selectUtxoList.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/selectUtxoList.tsx
@@ -2,6 +2,7 @@ import { FlashList } from '@shopify/flash-list'
 import { useLocalSearchParams, useRouter } from 'expo-router'
 import { useMemo, useState } from 'react'
 import { StyleSheet, View } from 'react-native'
+import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useShallow } from 'zustand/react/shallow'
 
 import { SSIconBubbles } from '@/components/icons'
@@ -32,6 +33,7 @@ type SortField = 'date' | 'amount'
 export default function SelectUtxoList() {
   const router = useRouter()
   const { id } = useLocalSearchParams<AccountSearchParams>()
+  const insets = useSafeAreaInsets()
 
   const account = useAccountsStore(
     (state) => state.accounts.find((account) => account.id === id)!
@@ -309,10 +311,12 @@ export default function SelectUtxoList() {
               />
             )
           }}
-          contentContainerStyle={{ paddingBottom: 80 }}
+          contentContainerStyle={{ paddingBottom: 80 + insets.bottom }}
         />
       </View>
-      <View style={styles.absoluteSubmitContainer}>
+      <View
+        style={[styles.absoluteSubmitContainer, { bottom: 20 + insets.bottom }]}
+      >
         <SSButton
           label={buttonLabel}
           variant="secondary"
@@ -338,7 +342,6 @@ export default function SelectUtxoList() {
 const styles = StyleSheet.create({
   absoluteSubmitContainer: {
     alignItems: 'center',
-    bottom: 20,
     position: 'absolute',
     width: '100%'
   },

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/unified/[index].tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/(common)/import/unified/[index].tsx
@@ -684,6 +684,7 @@ export default function UnifiedImport() {
                       placeholder={t('watchonly.importDescriptor.external')}
                       multiline
                       numberOfLines={3}
+                      status={externalDescriptorError ? 'invalid' : undefined}
                     />
                     {externalDescriptorError && (
                       <SSText
@@ -708,6 +709,7 @@ export default function UnifiedImport() {
                       placeholder={t('watchonly.importDescriptor.internal')}
                       multiline
                       numberOfLines={3}
+                      status={internalDescriptorError ? 'invalid' : undefined}
                     />
                     {internalDescriptorError && (
                       <SSText

--- a/apps/mobile/components/SSBubble.tsx
+++ b/apps/mobile/components/SSBubble.tsx
@@ -195,7 +195,7 @@ function SSBubble({
   }, [radius, mainY])
   const memoX = x - 150 / 2
   const memoParagraph = useMemo(() => {
-    if (!customFontManager) {
+    if (!customFontManager || !label) {
       return null
     }
 
@@ -225,7 +225,7 @@ function SSBubble({
           weight: 500
         }
       })
-      .addText(`  ${formatAddress(label || '-')}`)
+      .addText(`  ${formatAddress(label)}`)
       .pop()
       .build()
     para.layout(150)
@@ -234,6 +234,9 @@ function SSBubble({
 
   // Utxo from address
   const fromY = useMemo(() => {
+    if (!label) {
+      return memoY
+    }
     // spacing based on radius because Skia is not consistent for now
     if (radius > 10) {
       return mainY + radius / 2.5
@@ -242,7 +245,7 @@ function SSBubble({
       return mainY + radius / 2.2
     }
     return mainY + radius / 3.5
-  }, [radius, mainY])
+  }, [radius, mainY, memoY, label])
 
   const fromParagraph = useMemo(() => {
     if (!customFontManager) {
@@ -312,14 +315,16 @@ function SSBubble({
             y={mainY}
             width={200}
           />
-          <Group layer={<Paint opacity={descriptionOpacity} />}>
-            <Paragraph
-              paragraph={memoParagraph}
-              x={memoX}
-              y={memoY}
-              width={150}
-            />
-          </Group>
+          {memoParagraph && (
+            <Group layer={<Paint opacity={descriptionOpacity} />}>
+              <Paragraph
+                paragraph={memoParagraph}
+                x={memoX}
+                y={memoY}
+                width={150}
+              />
+            </Group>
+          )}
           <Group layer={<Paint opacity={dateAddressOpacity} />}>
             <Paragraph
               paragraph={fromParagraph}

--- a/apps/mobile/components/SSBubble.tsx
+++ b/apps/mobile/components/SSBubble.tsx
@@ -50,8 +50,6 @@ function SSBubble({
 }: SSBubbleProps) {
   const opacity = useSharedValue(0)
   const dimmedOpacity = useSharedValue(dimmed ? 0.3 : 1)
-  const isSelectedSharedValue = useSharedValue(selected)
-  isSelectedSharedValue.value = selected
 
   useEffect(() => {
     opacity.set(
@@ -70,14 +68,14 @@ function SSBubble({
   }, [dimmed, dimmedOpacity])
 
   const backgroundColor = useDerivedValue(() => {
-    if (isSelectedSharedValue.value) {
+    if (selected) {
       return Colors.white
     }
     if (isZoomedIn?.value) {
       return Colors.gray[300]
     }
     return Colors.gray[400]
-  }, [isZoomedIn, isSelectedSharedValue])
+  }, [isZoomedIn, selected])
 
   const descriptionOpacity = useDerivedValue(() => {
     const zoomedRadius = scale.value * radius

--- a/apps/mobile/components/SSTextInput.tsx
+++ b/apps/mobile/components/SSTextInput.tsx
@@ -2,7 +2,6 @@ import { StyleSheet, TextInput, View } from 'react-native'
 
 import SSVStack from '@/layouts/SSVStack'
 import { Colors, Sizes } from '@/styles'
-import { descriptorValidityCache } from '@/utils/validation'
 
 import SSText from './SSText'
 
@@ -36,23 +35,10 @@ function SSTextInput({
   const alignStyle = align === 'center' ? styles.alignCenter : styles.alignLeft
   const actionRightPadding = actionRight ? { paddingRight: 48 } : {}
 
-  // If no explicit status, derive from cache (populated by validateDescriptor calls)
-  const cachedValidity =
-    status === undefined && value
-      ? descriptorValidityCache.get(value)
-      : undefined
-  const resolvedStatus =
-    status ??
-    (cachedValidity === true
-      ? 'valid'
-      : cachedValidity === false
-        ? 'invalid'
-        : undefined)
-
   const statusStyle =
-    resolvedStatus === 'valid'
+    status === 'valid'
       ? styles.statusValid
-      : resolvedStatus === 'invalid'
+      : status === 'invalid'
         ? styles.statusInvalid
         : {}
 

--- a/apps/mobile/components/icons/SSIconBitcoin.tsx
+++ b/apps/mobile/components/icons/SSIconBitcoin.tsx
@@ -1,4 +1,4 @@
-import Svg, { Circle, Defs, G, type SvgProps } from 'react-native-svg'
+import Svg, { Circle, type SvgProps } from 'react-native-svg'
 
 import { type NavMenuItemIconProps } from '@/types/navigation/navMenu'
 
@@ -10,11 +10,7 @@ export default function SSIconBitcoin({
 }: IconProps & NavMenuItemIconProps) {
   return (
     <Svg width={width} height={height} viewBox="0 0 22 22" fill="none">
-      <G filter="url(#filter0_i_8288_24201)">
-        <Circle cx={11} cy={11} r={11} fill="#fff" />
-      </G>
-      <Circle cx={11} cy={11} r={10.5} stroke="#DCDCDC" />
-      <Defs />
+      <Circle cx={11} cy={11} r={10.5} stroke="#DCDCDC" strokeWidth={1.5} />
     </Svg>
   )
 }

--- a/apps/mobile/hooks/useAnimationEnd.ts
+++ b/apps/mobile/hooks/useAnimationEnd.ts
@@ -61,7 +61,7 @@ export const useAnimationEnd = (
         }
       }
     },
-    [onResetAnimationEnd, endValues.value]
+    [onResetAnimationEnd, endValues]
   )
 
   return { onAnimationEnd }

--- a/apps/mobile/utils/validation.ts
+++ b/apps/mobile/utils/validation.ts
@@ -59,19 +59,12 @@ function validateDescriptorChecksum(descriptor: string) {
   )
 }
 
-// Cache of descriptor validation results for reactive UI feedback
-export const descriptorValidityCache = new Map<string, boolean>()
-
 export function validateDescriptor(descriptor: string) {
-  const result = validateDescriptorInternal(descriptor, true)
-  descriptorValidityCache.set(descriptor, result)
-  return result
+  return validateDescriptorInternal(descriptor, true)
 }
 
 export function validateDescriptorFormat(descriptor: string) {
-  const result = validateDescriptorInternal(descriptor, false)
-  descriptorValidityCache.set(descriptor, result)
-  return result
+  return validateDescriptorInternal(descriptor, false)
 }
 
 function validateDescriptorInternal(


### PR DESCRIPTION
- **Removed shared-value write during render in `SSBubble`** — was mutating a Reanimated shared value inline in the render path; now done in an effect/event. Avoids a render-phase side effect.
- **Hid label placeholder in bubble when UTXO has no label** — empty-label UTXOs no longer show stray placeholder text in the bubble view.
- **Stopped reading shared value inside `useAnimationEnd` `useCallback` deps** — reading `.value` in a deps array doesn't trigger updates and breaks under react-compiler. Now reads safely.
- **Respected safe-area insets on UTXO select screens** — `selectUtxoBubbles` and `selectUtxoList` honor notch/home-indicator padding.
- **Bitcoin icon switched from filled to stroke** — visual change to `SSIconBitcoin`.
- **Fixed stale selected-UTXO total under react-compiler memoization** — total was caching stale selection; recomputes correctly now across `ioPreview`, `selectUtxoBubbles`, `selectUtxoList`.
- **Respected safe-area insets on sign-and-send screens** — same inset fix applied to `ioPreview`.
- **Stopped descriptor-validity cache from poisoning unrelated inputs** — cache key was too broad, so one input's validity leaked into others. Cache scoped properly in `SSTextInput` and `validation.ts`; also touches the unified import screen.
