### PR TITLE
style: polish pin input UI

### DIFF
--- a/apps/mobile/app/setPin.tsx
+++ b/apps/mobile/app/setPin.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
 import { useShallow } from 'zustand/react/shallow'
 
-import { SSIconCheckCircleThin, SSIconCircleXThin } from '@/components/icons'
+import { SSIconCheckCircleThin } from '@/components/icons'
 import SSButton from '@/components/SSButton'
 import SSPinInput from '@/components/SSPinInput'
 import SSText from '@/components/SSText'
@@ -16,6 +16,7 @@ import { getItem } from '@/storage/encrypted'
 import { useAuthStore } from '@/store/auth'
 import { useSettingsStore } from '@/store/settings'
 import { Layout, Sizes } from '@/styles'
+import { error as errorColor } from '@/styles/colors'
 import { emptyPin } from '@/utils/pin'
 
 type Stage = 'verify' | 'set' | 're-enter'
@@ -169,12 +170,9 @@ export default function SetPin() {
   function getFeedback() {
     if (stage === 'verify' && currentPinWrong && !currentPinFilled) {
       return (
-        <SSVStack itemsCenter gap="xs">
-          <SSIconCircleXThin height={32} width={32} />
-          <SSText uppercase size="lg" color="muted" center>
-            {t('auth.wrongPin')}
-          </SSText>
-        </SSVStack>
+        <SSText uppercase size="lg" center style={{ color: errorColor }}>
+          {t('auth.wrongPin')}
+        </SSText>
       )
     }
     if (stage === 're-enter' && confirmationPinFilled && pinsMatch) {
@@ -189,12 +187,9 @@ export default function SetPin() {
     }
     if (stage === 're-enter' && confirmationPinFilled && !pinsMatch) {
       return (
-        <SSVStack itemsCenter gap="xs">
-          <SSIconCircleXThin height={32} width={32} />
-          <SSText uppercase size="lg" color="muted" center>
-            {t('auth.pinsDontMatch')}
-          </SSText>
-        </SSVStack>
+        <SSText uppercase size="lg" center style={{ color: errorColor }}>
+          {t('auth.pinsDontMatch')}
+        </SSText>
       )
     }
     return null

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -4,9 +4,17 @@ import {
   type ReactNode,
   type SetStateAction,
   useEffect,
+  useRef,
   useState
 } from 'react'
 import { StyleSheet, TextInput, View } from 'react-native'
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming
+} from 'react-native-reanimated'
 
 import { PIN_SIZE } from '@/config/auth'
 import SSHStack from '@/layouts/SSHStack'
@@ -125,6 +133,7 @@ function SSPinInput({
                     isActive={isActive}
                     isFilled={isFilled}
                   />
+                  {isActive && <PinCellGlow />}
                 </View>
               </LinearGradient>
             )
@@ -151,9 +160,9 @@ function SSPinInput({
               : null}
           </View>
         ) : null}
+        {feedback ? <View style={styles.feedbackSlot}>{feedback}</View> : null}
       </SSVStack>
       <SSVStack gap="md" itemsCenter widthFull>
-        {feedback}
         <SSKeyboard
           onPress={handlePress}
           onClear={handleClear}
@@ -214,6 +223,31 @@ function PinDigitGlassOverlay({
         style={[styles.pinGlassEdge, styles.pinGlassRight, { width: edge }]}
       />
     </View>
+  )
+}
+
+function PinCellGlow() {
+  const opacity = useSharedValue(0)
+  const started = useRef(false)
+
+  if (!started.current) {
+    started.current = true
+    opacity.value = withRepeat(
+      withSequence(
+        withTiming(0.07, { duration: 500 }),
+        withTiming(0, { duration: 500 })
+      ),
+      -1
+    )
+  }
+
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: opacity.value }))
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={[styles.pinCellGlow, animatedStyle]}
+    />
   )
 }
 
@@ -284,6 +318,13 @@ const styles = StyleSheet.create({
     alignSelf: 'stretch',
     textAlign: 'center',
     width: '100%'
+  },
+  pinCellGlow: {
+    backgroundColor: Colors.white,
+    borderRadius: Sizes.pinInput.borderRadius,
+    inset: 0,
+    position: 'absolute',
+    zIndex: 2
   },
   pinGlassBottom: {
     bottom: 0,

--- a/apps/mobile/components/icons/SSIconCheckCircleThin.tsx
+++ b/apps/mobile/components/icons/SSIconCheckCircleThin.tsx
@@ -1,14 +1,43 @@
+import { useRef } from 'react'
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+  withDelay,
+  withTiming
+} from 'react-native-reanimated'
 import Svg, { Circle, G, Path, type SvgProps } from 'react-native-svg'
+
+const AnimatedCircle = Animated.createAnimatedComponent(Circle)
+const AnimatedPath = Animated.createAnimatedComponent(Path)
+
+const _CIRCLE_CIRCUMFERENCE = 2 * Math.PI * 17
+const CHECK_PATH_LENGTH = 22
 
 type IconProps = Pick<SvgProps, 'width' | 'height'>
 
 export default function SSIconCheckCircleThin({ width, height }: IconProps) {
+  const circleOpacity = useSharedValue(0)
+  const checkOffset = useSharedValue(CHECK_PATH_LENGTH)
+  const started = useRef(false)
+
+  if (!started.current) {
+    started.current = true
+    circleOpacity.value = withTiming(1, { duration: 350 })
+    checkOffset.value = withDelay(150, withTiming(0, { duration: 400 }))
+  }
+
+  const circleProps = useAnimatedProps(() => ({
+    opacity: circleOpacity.value
+  }))
+
+  const checkProps = useAnimatedProps(() => ({
+    strokeDashoffset: checkOffset.value
+  }))
+
   return (
     <Svg width={width} height={height} viewBox="0 0 35 35">
-      <G id="check-circle-thin" transform="translate(-0.5 -0.5)">
-        <Circle
-          id="Ellipse_10"
-          data-name="Ellipse 10"
+      <G transform="translate(-0.5 -0.5)">
+        <AnimatedCircle
           cx="17"
           cy="17"
           r="17"
@@ -16,15 +45,18 @@ export default function SSIconCheckCircleThin({ width, height }: IconProps) {
           fill="none"
           stroke="#fff"
           strokeWidth="1"
+          animatedProps={circleProps}
         />
-        <Path
-          id="Path_33"
-          data-name="Path 33"
+        <AnimatedPath
           d="M6.7,15.038l4.208,4.04L22.017,7.8"
           transform="translate(3.894 4.645)"
           fill="none"
           stroke="#fff"
-          strokeWidth="1"
+          strokeWidth="1.2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeDasharray={CHECK_PATH_LENGTH}
+          animatedProps={checkProps}
         />
       </G>
     </Svg>

--- a/apps/mobile/styles/sizes.ts
+++ b/apps/mobile/styles/sizes.ts
@@ -59,8 +59,8 @@ export const textInput = {
   },
   height: {
     default: 58,
-    large: 42,
-    small: 34
+    large: 56,
+    small: 42
   }
 }
 


### PR DESCRIPTION
## Summary

- **Animated check icon** (`SSIconCheckCircleThin`): circle fades in, checkmark draws in with a stroke-dashoffset animation via Reanimated
- **Active cell glow** (`SSPinInput`): pulsing white overlay on the currently active pin cell to indicate focus
- **Cleaner error feedback** (`setPin`): replaced icon + muted text stack with a single error-colored text line; feedback rendered in a reserved `feedbackSlot` to avoid layout shift
- **`sizes.ts`**: corrected `textInput` height values (`large: 56`, `small: 42`)