### PR TITLE
Release 0.3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.6] - 2026-06-10
+
+### Changed
+
+- Upgraded to Expo SDK 56.
+- Upgraded Bark React Native Bindings to `0.8.0` and dropped the access token.
+- New splash screen.
+- Bitcoin icon now uses a stroke instead of a filled style.
+
+### Fixed
+
+- Added missing Ark i18n strings.
+- Lock the Ark create form while the wallet is being created.
+- Show pending sats in the Ark balance during refresh.
+- `SSButton` tap blocked after the disabled state toggled.
+- Replaced broken `absoluteFill` spread with `inset: 0`.
+- Stopped the descriptor validity cache from poisoning unrelated inputs.
+- Respect safe area insets on the sign-and-send and UTXO select screens.
+- Stale selected UTXO total under react-compiler memoization.
+- Hide the label placeholder in the bubble when a UTXO has no label.
+- Electrum URL validation.
+- Esplora API responses with extra or optional fields failing to parse.
+- Incorrect usage of `useShallow` in explorer block transactions.

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <div align="center">
   <h1>Satsigner</h1>
-  <a href="https://satsigner.com/">satsigner.com</a>
   <p>Privacy-first bitcoin signer with complete UTXO control</p>
+  <a href="https://satsigner.com"><img alt="badge" src="https://shieldcn.dev/badge/satsigner.com.svg?logo=false"></a>
   <a href="https://satsigner.com/apk">
     <img alt="badge" src="https://shieldcn.dev/badge/Download%20latest%20APK.svg?variant=secondary&logo=lu%3ADownload">
   </a>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,11 @@
 
 <div align="center">
   <h1>Satsigner</h1>
-  <p>Privacy-first bitcoin signer with complete UTXO control</p>
   <a href="https://satsigner.com/">satsigner.com</a>
+  <p>Privacy-first bitcoin signer with complete UTXO control</p>
+  <a href="https://satsigner.com/apk">
+    <img alt="badge" src="https://shieldcn.dev/badge/Download%20latest%20APK.svg?variant=secondary&logo=lu%3ADownload">
+  </a>
 </div>
 
 <br />

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "type": "module",
   "sideEffects": false,

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -125,7 +125,7 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   scheme: getScheme(),
   slug: 'satsigner',
   userInterfaceStyle: 'dark',
-  version: '0.3.5',
+  version: '0.3.6',
   web: {
     favicon: './assets/favicon.png'
   }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@satsigner/mobile",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "description": "Privacy-first Bitcoin signer with complete UTXO control",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "satsigner",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "description": "Privacy-first Bitcoin signer with complete UTXO control",
   "keywords": [


### PR DESCRIPTION
## Release 0.3.6

### Changed

- Upgraded to Expo SDK 56.
- Upgraded Bark React Native Bindings to `0.8.0` and dropped the access token.
- New splash screen.
- Bitcoin icon now uses a stroke instead of a filled style.

### Fixed

- Added missing Ark i18n strings.
- Lock the Ark create form while the wallet is being created.
- Show pending sats in the Ark balance during refresh.
- `SSButton` tap blocked after the disabled state toggled.
- Replaced broken `absoluteFill` spread with `inset: 0`.
- Stopped the descriptor validity cache from poisoning unrelated inputs.
- Respect safe area insets on the sign-and-send and UTXO select screens.
- Stale selected UTXO total under react-compiler memoization.
- Hide the label placeholder in the bubble when a UTXO has no label.
- Electrum URL validation.
- Esplora API responses with extra or optional fields failing to parse.
- Incorrect usage of `useShallow` in explorer block transactions.