### PR TITLE
Fix androidStatusBar warning

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -38,9 +38,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     package: getUniqueIdentifier(),
     permissions: ['NFC']
   },
-  androidStatusBar: {
-    barStyle: 'light-content'
-  },
   assetBundlePatterns: ['**/*'],
   description: 'Privacy-first Bitcoin signer with complete UTXO control',
   experiments: {
@@ -110,6 +107,12 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
       }
     ],
     'expo-image',
+    [
+      'expo-status-bar',
+      {
+        style: 'light'
+      }
+    ],
     'expo-sharing',
     'expo-web-browser',
     '@secondts/bark-react-native',

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/_layout.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/_layout.tsx
@@ -9,7 +9,6 @@ import {
   type DrawerNavigationProp,
   useDrawerStatus
 } from 'expo-router/build/react-navigation/drawer'
-import { StatusBar } from 'expo-status-bar'
 import { useEffect, useMemo, useState } from 'react'
 import { Platform, type ViewStyle, View } from 'react-native'
 import { useSafeAreaInsets } from 'react-native-safe-area-context'
@@ -204,39 +203,36 @@ export default function StackLayout(params: { segment?: string }) {
   }, [params])
 
   return (
-    <>
-      <Stack
-        screenOptions={{
-          contentStyle: {
-            backgroundColor: Colors.gray[950]
-          },
-          headerBackVisible: false,
-          headerBackground: () => (
-            <View
-              style={{
-                alignItems: 'center',
-                backgroundColor: Colors.gray[950],
-                height: '100%',
-                justifyContent: 'center'
-              }}
-            />
-          ),
-          headerLeft: () => <HeaderLeft isShowNav={isShowNav} />,
-          headerRight: () => <HeaderRight />,
-          // Native stack accepts height; Expo's Stack typings only allow backgroundColor.
-          headerStyle: stackHeaderStyle as { backgroundColor?: string },
-          headerTintColor: Colors.gray[200],
-          headerTitle: () => (
-            <SSText uppercase style={{ letterSpacing: 1 }}>
-              {t('app.name')}
-            </SSText>
-          ),
-          headerTitleAlign: 'center'
-        }}
-      >
-        {homeScreen}
-      </Stack>
-      <StatusBar style="light" />
-    </>
+    <Stack
+      screenOptions={{
+        contentStyle: {
+          backgroundColor: Colors.gray[950]
+        },
+        headerBackVisible: false,
+        headerBackground: () => (
+          <View
+            style={{
+              alignItems: 'center',
+              backgroundColor: Colors.gray[950],
+              height: '100%',
+              justifyContent: 'center'
+            }}
+          />
+        ),
+        headerLeft: () => <HeaderLeft isShowNav={isShowNav} />,
+        headerRight: () => <HeaderRight />,
+        // Native stack accepts height; Expo's Stack typings only allow backgroundColor.
+        headerStyle: stackHeaderStyle as { backgroundColor?: string },
+        headerTintColor: Colors.gray[200],
+        headerTitle: () => (
+          <SSText uppercase style={{ letterSpacing: 1 }}>
+            {t('app.name')}
+          </SSText>
+        ),
+        headerTitleAlign: 'center'
+      }}
+    >
+      {homeScreen}
+    </Stack>
   )
 }


### PR DESCRIPTION
### In this Pull Request

When we ran `pnpm expo prebuild` it was giving the following warning:

```
android: SYSTEM_BARS_PLUGIN: `androidStatusBar` is deprecated and has no effect. Use the `expo-status-bar` plugin configuration instead.
```

To fix it we:

- Replace deprecated `androidStatusBar` config with `expo-status-bar` config plugin (`style: 'light'`)
- Remove redundant `<StatusBar style="light" />` from tabs layout