### PR TITLE
Fix: Pin entry skip squares on fast taps

### DIFF
--- a/apps/mobile/app/setPin.tsx
+++ b/apps/mobile/app/setPin.tsx
@@ -67,12 +67,10 @@ export default function SetPin() {
   const pinsMatch = pinArray.join('') === confirmationPinArray.join('')
 
   function handleCurrentPinChange(newPin: React.SetStateAction<string[]>) {
-    const resolved =
-      typeof newPin === 'function' ? newPin(currentPinArray) : newPin
-    if (currentPinWrong && resolved.some((d) => d !== '')) {
+    setCurrentPinArray(newPin)
+    if (currentPinWrong) {
       setCurrentPinWrong(false)
     }
-    setCurrentPinArray(resolved)
   }
 
   async function handleVerifyPin() {

--- a/apps/mobile/components/SSPinInput.tsx
+++ b/apps/mobile/components/SSPinInput.tsx
@@ -4,8 +4,7 @@ import {
   type ReactNode,
   type SetStateAction,
   useEffect,
-  useRef,
-  useState
+  useRef
 } from 'react'
 import { StyleSheet, TextInput, View } from 'react-native'
 import Animated, {
@@ -20,6 +19,13 @@ import { PIN_SIZE } from '@/config/auth'
 import SSHStack from '@/layouts/SSHStack'
 import SSVStack from '@/layouts/SSVStack'
 import { Colors, Sizes } from '@/styles'
+import {
+  deletePinDigit,
+  emptyPin,
+  fillPinDigit,
+  getPinCursorIndex,
+  isPinFilled
+} from '@/utils/pin'
 
 import SSKeyboard from './SSKeyboard'
 import SSText from './SSText'
@@ -47,45 +53,34 @@ function SSPinInput({
   withClear = true,
   withDelete = true
 }: SSPinInputProps) {
-  const [currentIndex, setCurrentIndex] = useState(0)
+  const currentIndex = getPinCursorIndex(pin)
+
+  const fillEndedFiredRef = useRef(false)
 
   useEffect(() => {
-    if (pin.join('') === '') {
-      setCurrentIndex(0)
-    }
-  }, [pin])
-
-  function handleDelete() {
-    if (currentIndex <= 0) {
+    if (!isPinFilled(pin)) {
+      fillEndedFiredRef.current = false
       return
     }
-    const indexToClear = currentIndex - 1
-    const newPin = [...pin]
-    newPin[indexToClear] = ''
-    setCurrentIndex(indexToClear)
-    setPin(newPin)
+    if (fillEndedFiredRef.current) {
+      return
+    }
+    fillEndedFiredRef.current = true
+    if (onFillEnded) {
+      onFillEnded(pin.join(''))
+    }
+  }, [pin, onFillEnded])
+
+  function handleDelete() {
+    setPin(deletePinDigit)
   }
 
   function handleClear() {
-    setCurrentIndex(0)
-    setPin(Array.from({ length: PIN_SIZE }).map((_) => ''))
+    setPin(emptyPin())
   }
 
   function handlePress(digit: string) {
-    const newPin = [...pin]
-    const lastIndex = PIN_SIZE - 1
-    if (currentIndex > lastIndex) {
-      return
-    }
-
-    newPin[currentIndex] = digit
-    setPin(newPin)
-
-    if (currentIndex === lastIndex && onFillEnded) {
-      onFillEnded(newPin.join(''))
-    }
-
-    setCurrentIndex((currentValue) => currentValue + 1)
+    setPin((prev) => fillPinDigit(prev, digit))
   }
 
   return (

--- a/apps/mobile/tests/unit/utils/pin.test.ts
+++ b/apps/mobile/tests/unit/utils/pin.test.ts
@@ -1,0 +1,111 @@
+import {
+  deletePinDigit,
+  emptyPin,
+  fillPinDigit,
+  getPinCursorIndex,
+  isPinFilled
+} from '@/utils/pin'
+
+describe('pin utils', () => {
+  describe('fillPinDigit', () => {
+    it('fills the first empty cell', () => {
+      expect(fillPinDigit(['', '', '', ''], '1')).toStrictEqual([
+        '1',
+        '',
+        '',
+        ''
+      ])
+      expect(fillPinDigit(['1', '', '', ''], '2')).toStrictEqual([
+        '1',
+        '2',
+        '',
+        ''
+      ])
+      expect(fillPinDigit(['1', '2', '3', ''], '4')).toStrictEqual([
+        '1',
+        '2',
+        '3',
+        '4'
+      ])
+    })
+
+    it('is a no-op when the pin is full', () => {
+      const pin = ['1', '2', '3', '4']
+      expect(fillPinDigit(pin, '5')).toBe(pin)
+    })
+
+    it('does not mutate the input array', () => {
+      const pin = ['', '', '', '']
+      fillPinDigit(pin, '1')
+      expect(pin).toStrictEqual(['', '', '', ''])
+    })
+
+    it('never skips cells when presses are chained as functional updates', () => {
+      // Regression test for the auth screen bug where rapid presses were
+      // applied to a stale pin snapshot, leaving gaps like ['1', '', '1', '1'].
+      // Chaining each press on the previous result models how React resolves
+      // queued functional updaters within a single batch.
+      let pin = emptyPin()
+      for (const digit of ['1', '1', '1', '1']) {
+        pin = fillPinDigit(pin, digit)
+      }
+      expect(pin).toStrictEqual(['1', '1', '1', '1'])
+      expect(pin.join('')).toBe('1111')
+    })
+
+    it('keeps digits contiguous regardless of press count', () => {
+      let pin = emptyPin()
+      pin = fillPinDigit(pin, '1')
+      pin = fillPinDigit(pin, '2')
+      expect(pin).toStrictEqual(['1', '2', '', ''])
+      expect(getPinCursorIndex(pin)).toBe(2)
+    })
+  })
+
+  describe('deletePinDigit', () => {
+    it('clears the last filled cell', () => {
+      expect(deletePinDigit(['1', '2', '', ''])).toStrictEqual([
+        '1',
+        '',
+        '',
+        ''
+      ])
+      expect(deletePinDigit(['1', '2', '3', '4'])).toStrictEqual([
+        '1',
+        '2',
+        '3',
+        ''
+      ])
+    })
+
+    it('is a no-op when the pin is empty', () => {
+      const pin = ['', '', '', '']
+      expect(deletePinDigit(pin)).toBe(pin)
+    })
+
+    it('undoes a fill', () => {
+      const pin = fillPinDigit(emptyPin(), '7')
+      expect(deletePinDigit(pin)).toStrictEqual(emptyPin())
+    })
+  })
+
+  describe('getPinCursorIndex', () => {
+    it('returns the first empty index', () => {
+      expect(getPinCursorIndex(['', '', '', ''])).toBe(0)
+      expect(getPinCursorIndex(['1', '', '', ''])).toBe(1)
+      expect(getPinCursorIndex(['1', '2', '3', ''])).toBe(3)
+    })
+
+    it('returns the pin length when full', () => {
+      expect(getPinCursorIndex(['1', '2', '3', '4'])).toBe(4)
+    })
+  })
+
+  describe('isPinFilled', () => {
+    it('detects a full pin', () => {
+      expect(isPinFilled(['1', '2', '3', '4'])).toBe(true)
+      expect(isPinFilled(['1', '2', '3', ''])).toBe(false)
+      expect(isPinFilled(['', '', '', ''])).toBe(false)
+    })
+  })
+})

--- a/apps/mobile/utils/pin.ts
+++ b/apps/mobile/utils/pin.ts
@@ -4,4 +4,39 @@ function emptyPin(): string[] {
   return Array.from<string>({ length: PIN_SIZE }).fill('')
 }
 
-export { emptyPin }
+function getPinCursorIndex(pin: string[]): number {
+  const firstEmptyIndex = pin.indexOf('')
+  return firstEmptyIndex === -1 ? pin.length : firstEmptyIndex
+}
+
+function isPinFilled(pin: string[]): boolean {
+  return !pin.includes('')
+}
+
+function fillPinDigit(pin: string[], digit: string): string[] {
+  const index = pin.indexOf('')
+  if (index === -1) {
+    return pin
+  }
+  const newPin = [...pin]
+  newPin[index] = digit
+  return newPin
+}
+
+function deletePinDigit(pin: string[]): string[] {
+  const indexToClear = getPinCursorIndex(pin) - 1
+  if (indexToClear < 0) {
+    return pin
+  }
+  const newPin = [...pin]
+  newPin[indexToClear] = ''
+  return newPin
+}
+
+export {
+  deletePinDigit,
+  emptyPin,
+  fillPinDigit,
+  getPinCursorIndex,
+  isPinFilled
+}


### PR DESCRIPTION
### Bug

Fast taps on pin pad sometimes skip squares. Press 1,1,1 → shows `1-11` → auth fail. Race: cursor state update functional (never lost), pin array update non-functional from stale render closure (lost when two presses land in one batch). Cursor move 2, only 1 digit write.

### Fix

- Kill `currentIndex` state. Cursor now derived from pin array (first empty cell). One source of truth, no desync possible.
- All pin mutations through functional updaters. React chain them in order so lost update impossible.
- `onFillEnded` fire from effect with once-per-fill ref guard, re-arm on reset. Old sync call could join stale 3-char pin.
- `setPin.tsx` verify wrapper pass updater through raw. Old code resolved updater against stale closure: same race.
- Pin logic extracted to `utils/pin.ts` pure functions.

### Tests
- New `pin.test.ts`: 11 tests, incl. regression test chaining rapid presses like React batch.
