### PR TITLE
fix(mobile): privacy draft persistence and preview chart classification

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/index.tsx
@@ -102,8 +102,14 @@ import { type Address } from '@/types/models/Address'
 import { type Utxo } from '@/types/models/Utxo'
 import { type AccountSearchParams } from '@/types/navigation/searchParams'
 import { appNetworkToBdkNetwork } from '@/utils/bitcoin'
+import { getDraftIoCounts } from '@/utils/draftSelection'
 import { getFiatPriceApiUrl } from '@/utils/fiatData'
-import { formatAddress, formatDate, formatNumber } from '@/utils/format'
+import {
+  formatAddress,
+  formatDate,
+  formatFiatPrice,
+  formatNumber
+} from '@/utils/format'
 import { parseAccountAddressesDetails } from '@/utils/parse'
 import {
   createScanThroughputTracker,
@@ -128,9 +134,14 @@ function DraftTransactionCard({ accountId }: { accountId: string }) {
   const [drafts, clearTransaction] = useTransactionBuilderStore(
     useShallow((state) => [state.drafts, state.clearTransaction])
   )
+  const [btcPrice, fiatCurrency] = usePriceStore(
+    useShallow((state) => [state.btcPrice, state.fiatCurrency])
+  )
+  const privacyMode = useSettingsStore((state) => state.privacyMode)
+  const { showCurrentFiat } = useFiatData()
 
   const draft = drafts[accountId]
-  const inputCount = Object.keys(draft?.inputs ?? {}).length
+  const { inputCount, outputCount } = getDraftIoCounts(draft)
   const outputs = draft?.outputs ?? []
   const fee = draft?.fee ?? 0
   const totalOut = outputs.reduce((sum, o) => sum + o.amount, 0)
@@ -139,9 +150,13 @@ function DraftTransactionCard({ accountId }: { accountId: string }) {
       ? t('transaction.input.singular')
       : t('transaction.input.plural')
   const outputLabel =
-    outputs.length === 1
+    outputCount === 1
       ? t('transaction.output.singular')
       : t('transaction.output.plural')
+  const currentFiatPrice =
+    showCurrentFiat && btcPrice && btcPrice > 0 && totalOut > 0
+      ? formatFiatPrice(totalOut, btcPrice)
+      : ''
 
   return (
     <TouchableOpacity
@@ -169,10 +184,7 @@ function DraftTransactionCard({ accountId }: { accountId: string }) {
             {t('transaction.unsent')}
           </SSText>
         </SSHStack>
-        <SSHStack
-          justifyBetween
-          style={{ alignItems: 'flex-end', marginTop: 5 }}
-        >
+        <SSVStack gap="none" style={{ marginTop: 5 }}>
           <SSHStack gap="sm" style={{ alignItems: 'center' }}>
             <SSIconOutgoing height={21} width={21} />
             <SSText
@@ -180,17 +192,31 @@ function DraftTransactionCard({ accountId }: { accountId: string }) {
               weight="light"
               style={{ color: Colors.gray[400] }}
             >
-              {totalOut > 0 ? totalOut.toLocaleString() : '--'}
+              {privacyMode
+                ? '••••'
+                : totalOut > 0
+                  ? totalOut.toLocaleString()
+                  : '--'}
             </SSText>
             <SSText color="muted" size="sm">
               {t('bitcoin.sats')}
             </SSText>
           </SSHStack>
-        </SSHStack>
+          {currentFiatPrice !== '' ? (
+            <SSHStack gap="xs" style={{ height: 22, marginTop: 2 }}>
+              <SSText style={{ color: Colors.gray[400] }} size="sm">
+                {privacyMode ? '••••' : currentFiatPrice}
+              </SSText>
+              <SSText style={{ color: Colors.gray[500] }} size="sm">
+                {fiatCurrency}
+              </SSText>
+            </SSHStack>
+          ) : null}
+        </SSVStack>
         <SSHStack justifyBetween style={{ marginTop: 2 }}>
           <SSText size="xs" color="muted">
             {inputCount} {inputLabel}
-            {outputs.length > 0 ? `, ${outputs.length} ${outputLabel}` : ''}
+            {outputCount > 0 ? `, ${outputCount} ${outputLabel}` : ''}
             {fee > 0 ? `, ${fee.toLocaleString()} ${t('transaction.fee')}` : ''}
           </SSText>
           <TouchableOpacity

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/ioPreview.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/ioPreview.tsx
@@ -97,7 +97,10 @@ import {
   buildStonewallMaterializationPlan,
   buildStonewallPreviewOutputs,
   CHART_REMAINING_BALANCE_LOCAL_ID,
-  getStonewallPaymentContext
+  getEphemeralChangeOutputLocalIds,
+  getStonewallPaymentContext,
+  isStonewallManagedOutput,
+  isStonewallPreviewLocalId
 } from '@/utils/stonewall'
 import { time } from '@/utils/time'
 import { estimateTransactionSize } from '@/utils/transaction'
@@ -151,7 +154,12 @@ export default function IOPreview() {
     setFeeRate,
     setFee,
     clearPsbt,
-    clearTransaction
+    clearTransaction,
+    selectedAutoSelectUtxos,
+    setSelectedAutoSelectUtxos,
+    stonewallPreview,
+    setStonewallPreview,
+    clearStonewallPreview
   ] = useTransactionBuilderStore(
     useShallow((state) => [
       state.inputs,
@@ -167,7 +175,12 @@ export default function IOPreview() {
       state.setFeeRate,
       state.setFee,
       state.clearPsbt,
-      state.clearTransaction
+      state.clearTransaction,
+      state.selectedAutoSelectUtxos,
+      state.setSelectedAutoSelectUtxos,
+      state.stonewallPreview,
+      state.setStonewallPreview,
+      state.clearStonewallPreview
     ])
   )
 
@@ -175,48 +188,29 @@ export default function IOPreview() {
   const wallet = useGetAccountWallet(id!)
   const { changeAddress, secondChangeAddress, decoyAddress } =
     getUnusedInternalAddresses(account, wallet)
-  const [stonewallChangeValues, setStonewallChangeValues] = useState<number[]>(
-    []
-  )
-  const [stonewallFakeMixValues, setStonewallFakeMixValues] = useState<
-    number[]
-  >([])
-  const [stonewallFee, setStonewallFee] = useState<number | null>(null)
-  const [excludedUtxoOutpoints, setExcludedUtxoOutpoints] = useState<
-    Set<string>
-  >(() => new Set())
+  const stonewallChangeValues = stonewallPreview.changeValues
+  const stonewallFakeMixValues = stonewallPreview.fakeMixValues
+  const stonewallFee = stonewallPreview.fee
+  const stonewallLabelOverrides = stonewallPreview.labelOverrides
+  const excludedUtxoOutpoints = new Set(stonewallPreview.excludedUtxoOutpoints)
   const [removeInputModalVisible, setRemoveInputModalVisible] = useState(false)
   const [inputToRemove, setInputToRemove] = useState<Utxo | null>(null)
-  const [shouldRemoveChange, setShouldRemoveChange] = useState(true)
-  const shouldRemoveChangeRef = useRef(true)
 
-  function updateShouldRemoveChange(value: boolean) {
-    shouldRemoveChangeRef.current = value
-    setShouldRemoveChange(value)
-  }
-
-  // this removes the change addresses if the user goes back to the IO preview.
-  // we add the change address(es) as outputs before moving to the next step.
-  useEffect(() => {
-    if (!changeAddress || !shouldRemoveChangeRef.current) {
-      return
-    }
-    const changeAddresses = new Set(
-      [changeAddress, secondChangeAddress, decoyAddress].filter(Boolean)
-    )
-    for (const output of outputs) {
-      if (changeAddresses.has(output.to)) {
-        removeOutput(output.localId)
+  // Only strip on focus — watching outputs races with materialize on continue.
+  useFocusEffect(
+    useCallback(() => {
+      const { outputs: currentOutputs, removeOutput: remove } =
+        useTransactionBuilderStore.getState()
+      const localIds = getEphemeralChangeOutputLocalIds(currentOutputs, [
+        changeAddress,
+        secondChangeAddress,
+        decoyAddress
+      ])
+      for (const localId of localIds) {
+        remove(localId)
       }
-    }
-  }, [
-    outputs,
-    changeAddress,
-    secondChangeAddress,
-    decoyAddress,
-    shouldRemoveChange,
-    removeOutput
-  ])
+    }, [changeAddress, secondChangeAddress, decoyAddress])
+  )
 
   const [fiatCurrency, satsToFiat, btcPrice] = usePriceStore(
     useShallow((state) => [
@@ -227,20 +221,6 @@ export default function IOPreview() {
   )
 
   const { blockHeight, nextBlockFee, blockHeightSource } = useNetworkInfo()
-
-  const [selectedAutoSelectUtxos, setSelectedAutoSelectUtxos] =
-    useState<AutoSelectUtxosAlgorithm>('user')
-
-  useFocusEffect(
-    useCallback(() => {
-      if (selectedAutoSelectUtxos !== 'privacy') {
-        return
-      }
-
-      shouldRemoveChangeRef.current = true
-      updateShouldRemoveChange(true)
-    }, [selectedAutoSelectUtxos])
-  )
 
   const markUriAutoSelectPendingRef = useRef<(() => void) | undefined>(
     undefined
@@ -473,6 +453,7 @@ export default function IOPreview() {
           fakeMixLabel: stonewallPaymentContext.paymentLabel,
           fakeMixValues: stonewallFakeMixValues,
           fee: stonewallFee,
+          labelOverrides: stonewallLabelOverrides,
           secondChangeAddress
         })
       : []
@@ -681,12 +662,42 @@ export default function IOPreview() {
       return
     }
 
+    if (isStonewallPreviewLocalId(currentOutputLocalId)) {
+      if (!currentOutputLocalId || !outputLabel.trim()) {
+        return
+      }
+      setStonewallPreview({
+        labelOverrides: {
+          ...stonewallLabelOverrides,
+          [currentOutputLocalId]: outputLabel
+        }
+      })
+      setAddOutputModalVisible(false)
+      resetLocalOutput()
+      return
+    }
+
     const outputIndex = outputs.findIndex(
       (output) => output.localId === currentOutputLocalId
     )
+    const existing = outputIndex === -1 ? undefined : outputs[outputIndex]
+
+    if (isStonewallManagedOutput(existing) && existing) {
+      updateOutput(existing.localId, {
+        amount: existing.amount,
+        kind: existing.kind,
+        label: outputLabel,
+        to: existing.to
+      })
+      setOutputsCount((prev: number) => prev + 1)
+      setAddOutputModalVisible(false)
+      resetLocalOutput()
+      return
+    }
 
     const output = {
       amount: outputAmount,
+      kind: existing?.kind,
       label: outputLabel,
       to: stripBitcoinPrefix(outputTo)
     }
@@ -704,6 +715,15 @@ export default function IOPreview() {
 
   function handleRemoveOutput() {
     if (!currentOutputLocalId) {
+      return
+    }
+    if (isStonewallPreviewLocalId(currentOutputLocalId)) {
+      return
+    }
+    const existing = outputs.find(
+      (output) => output.localId === currentOutputLocalId
+    )
+    if (isStonewallManagedOutput(existing)) {
       return
     }
     removeOutput(currentOutputLocalId)
@@ -733,6 +753,7 @@ export default function IOPreview() {
       fakeMixLabel: stonewallPaymentContext.paymentLabel,
       fakeMixValues: stonewallFakeMixValues,
       fee: stonewallFee,
+      labelOverrides: stonewallLabelOverrides,
       secondChangeAddress
     })
 
@@ -740,8 +761,16 @@ export default function IOPreview() {
       return false
     }
 
-    updateShouldRemoveChange(false)
     setFee(plan.fee)
+
+    const alreadyMaterialized = useTransactionBuilderStore
+      .getState()
+      .outputs.some(
+        (output) => output.kind === 'fakeMix' || output.kind === 'change'
+      )
+    if (alreadyMaterialized) {
+      return true
+    }
 
     for (const output of plan.outputs) {
       addOutput(output)
@@ -757,10 +786,7 @@ export default function IOPreview() {
       return
     }
 
-    if (
-      selectedAutoSelectUtxos === 'privacy' ||
-      selectedAutoSelectUtxos === 'efficiency'
-    ) {
+    if (selectedAutoSelectUtxos === 'efficiency') {
       return
     }
 
@@ -774,16 +800,29 @@ export default function IOPreview() {
     const outputIndex = outputs.findIndex(
       (output) => output.localId === localId
     )
-    if (outputIndex === -1) {
+    if (outputIndex !== -1) {
+      setOutputTo(outputs[outputIndex].to)
+      setOutputAmount(outputs[outputIndex].amount)
+      setOriginalOutputAmount(outputs[outputIndex].amount)
+      setOutputLabel(outputs[outputIndex].label)
+      setCurrentOutputNumber(outputIndex + 1)
+      setAddOutputModalVisible(true)
       return
     }
 
-    setOutputTo(outputs[outputIndex].to)
-    setOutputAmount(outputs[outputIndex].amount)
-    setOriginalOutputAmount(outputs[outputIndex].amount)
-    setOutputLabel(outputs[outputIndex].label)
-    setCurrentOutputNumber(outputIndex + 1)
+    const previewIndex = chartStonewallPreviewOutputs.findIndex(
+      (output) => output.localId === localId
+    )
+    if (previewIndex === -1) {
+      return
+    }
 
+    const preview = chartStonewallPreviewOutputs[previewIndex]
+    setOutputTo(preview.to)
+    setOutputAmount(preview.amount)
+    setOriginalOutputAmount(preview.amount)
+    setOutputLabel(preview.label)
+    setCurrentOutputNumber(outputs.length + previewIndex + 1)
     setAddOutputModalVisible(true)
   }
 
@@ -842,9 +881,12 @@ export default function IOPreview() {
     )
 
     setAccountUtxos(stonewallResult.inputs)
-    setStonewallChangeValues(changeValues)
-    setStonewallFakeMixValues(fakeMixValues)
-    setStonewallFee(stonewallResult.fee)
+    setStonewallPreview({
+      changeValues,
+      excludedUtxoOutpoints: Array.from(excluded),
+      fakeMixValues,
+      fee: stonewallResult.fee
+    })
     setFee(stonewallResult.fee)
 
     if (effectiveFeeRate !== localFeeRate) {
@@ -881,7 +923,6 @@ export default function IOPreview() {
       nextExcluded.add(outpoint)
 
       if (applyStonewallSelection(nextExcluded)) {
-        setExcludedUtxoOutpoints(nextExcluded)
         setRemoveInputModalVisible(false)
         setInputToRemove(null)
       }
@@ -914,10 +955,7 @@ export default function IOPreview() {
       if (decoyOutput) {
         removeOutput(decoyOutput.localId)
       }
-      setStonewallChangeValues([])
-      setStonewallFakeMixValues([])
-      setStonewallFee(null)
-      setExcludedUtxoOutpoints(new Set())
+      clearStonewallPreview()
     }
 
     const { effectiveFeeRate, userPaymentAmount } = getStonewallPaymentContext({
@@ -952,7 +990,6 @@ export default function IOPreview() {
         }
 
         setPreviousUserSelectedUtxos(getInputs())
-        setExcludedUtxoOutpoints(new Set())
         selectionSucceeded = applyStonewallSelection(new Set())
 
         break
@@ -1052,7 +1089,6 @@ export default function IOPreview() {
         return
       }
 
-      updateShouldRemoveChange(false)
       addOutput({
         amount: remainingBalance,
         label: t('sign.changeAddressLabelDefault'),
@@ -1119,9 +1155,27 @@ export default function IOPreview() {
     setLoadHistory(!loadHistory)
   }
 
-  const ownAddressesSet = account
-    ? new Set(account.addresses.map((address) => address.address))
-    : new Set<string>()
+  const ownAddressesSet = useMemo(() => {
+    const addresses = new Set(
+      account ? account.addresses.map((entry) => entry.address.trim()) : []
+    )
+    for (const address of [changeAddress, secondChangeAddress, decoyAddress]) {
+      const normalized = address?.trim()
+      if (normalized) {
+        addresses.add(normalized)
+      }
+    }
+    return addresses
+  }, [account, changeAddress, secondChangeAddress, decoyAddress])
+
+  const editingOutput =
+    outputs.find((output) => output.localId === currentOutputLocalId) ??
+    chartStonewallPreviewOutputs.find(
+      (output) => output.localId === currentOutputLocalId
+    )
+  const isEditingStonewallManagedOutput =
+    isStonewallManagedOutput(editingOutput) ||
+    isStonewallPreviewLocalId(currentOutputLocalId)
 
   const chartOnPressInput = handleOnPressInput
 
@@ -1443,25 +1497,31 @@ export default function IOPreview() {
               </SSVStack>
               <SSVStack gap="md">
                 <SSVStack gap="none">
-                  <SSAmountInput
-                    key={`amount-input-${outputsCount}`}
-                    min={DUST_LIMIT}
-                    max={
-                      currentOutputLocalId
-                        ? Math.max(
-                            remainingSats + originalOutputAmount - minerFee,
-                            DUST_LIMIT
-                          )
-                        : Math.max(remainingSats - minerFee, DUST_LIMIT)
+                  <View
+                    pointerEvents={
+                      isEditingStonewallManagedOutput ? 'none' : 'auto'
                     }
-                    value={currentOutputLocalId ? outputAmount : DUST_LIMIT}
-                    remainingSats={
-                      currentOutputLocalId
-                        ? remainingSats + originalOutputAmount - minerFee
-                        : remainingSats - minerFee
-                    }
-                    onValueChange={(value) => setOutputAmount(value)}
-                  />
+                  >
+                    <SSAmountInput
+                      key={`amount-input-${outputsCount}`}
+                      min={DUST_LIMIT}
+                      max={
+                        currentOutputLocalId
+                          ? Math.max(
+                              remainingSats + originalOutputAmount - minerFee,
+                              DUST_LIMIT
+                            )
+                          : Math.max(remainingSats - minerFee, DUST_LIMIT)
+                      }
+                      value={currentOutputLocalId ? outputAmount : DUST_LIMIT}
+                      remainingSats={
+                        currentOutputLocalId
+                          ? remainingSats + originalOutputAmount - minerFee
+                          : remainingSats - minerFee
+                      }
+                      onValueChange={(value) => setOutputAmount(value)}
+                    />
+                  </View>
                 </SSVStack>
                 <SSVStack>
                   <SSTextInput
@@ -1470,6 +1530,7 @@ export default function IOPreview() {
                     align="left"
                     multiline
                     numberOfLines={4}
+                    editable={!isEditingStonewallManagedOutput}
                     style={{
                       fontFamily: Typography.sfProMono,
                       fontSize: 22,
@@ -1480,20 +1541,22 @@ export default function IOPreview() {
                     }}
                     onChangeText={(text) => setOutputTo(text)}
                   />
-                  <SSHStack gap="md">
-                    <SSButton
-                      variant="outline"
-                      label={t('common.paste')}
-                      style={{ flex: 1 }}
-                      onPress={pasteFromClipboard}
-                    />
-                    <SSButton
-                      variant="outline"
-                      label={t('camera.scanQRCode')}
-                      style={{ flex: 1 }}
-                      onPress={() => setCameraModalVisible(true)}
-                    />
-                  </SSHStack>
+                  {!isEditingStonewallManagedOutput ? (
+                    <SSHStack gap="md">
+                      <SSButton
+                        variant="outline"
+                        label={t('common.paste')}
+                        style={{ flex: 1 }}
+                        onPress={pasteFromClipboard}
+                      />
+                      <SSButton
+                        variant="outline"
+                        label={t('camera.scanQRCode')}
+                        style={{ flex: 1 }}
+                        onPress={() => setCameraModalVisible(true)}
+                      />
+                    </SSHStack>
+                  ) : null}
                 </SSVStack>
                 <SSTextInput
                   multiline
@@ -1516,7 +1579,9 @@ export default function IOPreview() {
                     label={t('transaction.build.remove.output.title')}
                     variant="danger"
                     style={{ flex: 1 }}
-                    disabled={!currentOutputLocalId}
+                    disabled={
+                      !currentOutputLocalId || isEditingStonewallManagedOutput
+                    }
                     onPress={handleRemoveOutput}
                   />
                   <SSButton

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/previewTransaction.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/previewTransaction.tsx
@@ -927,6 +927,7 @@ function PreviewTransaction() {
 
     const vout = outputs.map((output: Output) => ({
       address: output.to,
+      kind: output.kind,
       label: output.label || '',
       script: '' as string | number[],
       value: output.amount

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/signTransaction.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/signTransaction.tsx
@@ -89,6 +89,7 @@ function buildSignTransactionChartModel(
 
   const vout = outputs.map((output: Output) => ({
     address: output.to,
+    kind: output.kind,
     label: output.label || '',
     script: '' as string | number[],
     value: output.amount

--- a/apps/mobile/components/SSCurrentTransactionChart.tsx
+++ b/apps/mobile/components/SSCurrentTransactionChart.tsx
@@ -37,7 +37,10 @@ import {
 import { getFeePercentage, isHighMinerFee } from '@/utils/feeWarnings'
 import { formatAddress, formatNumber } from '@/utils/format'
 import { buildSankeyRibbonPlan } from '@/utils/sankeyFlowWidths'
-import { CHART_REMAINING_BALANCE_LOCAL_ID } from '@/utils/stonewall'
+import {
+  CHART_REMAINING_BALANCE_LOCAL_ID,
+  classifyChartOutput
+} from '@/utils/stonewall'
 import { estimateTransactionSize } from '@/utils/transaction'
 import {
   getOutputMaxAllowedSats,
@@ -299,12 +302,7 @@ function SSCurrentTransactionChart({
           address: output?.to ? formatAddress(output?.to, 6) : '',
           fiatCurrency,
           fiatValue: formatNumber(satsToFiat(output.amount), 2),
-          isFakeMix: output.kind === 'fakeMix',
-          isSelfSend: !!(
-            output.to &&
-            ownAddresses.has(output.to) &&
-            output.kind !== 'fakeMix'
-          ),
+          ...classifyChartOutput(output, ownAddresses),
           isUnspent: true,
           label: output.label,
           maxAllowedSats:

--- a/apps/mobile/components/SSSankeyLinks.tsx
+++ b/apps/mobile/components/SSSankeyLinks.tsx
@@ -119,13 +119,16 @@ function SSSankeyLinks({
 
         const isUnspent = targetNode.ioData?.isUnspent === true
         const isFakeMixOutput = targetNode.ioData?.isFakeMix === true
+        const isChangeOutput =
+          targetNode.ioData?.isChange === true ||
+          targetNode.localId === CHART_REMAINING_BALANCE_LOCAL_ID
         const isSelfSendOutput =
           targetNode.ioData?.isSelfSend === true &&
-          targetNode.ioData?.isFakeMix !== true
+          targetNode.ioData?.isFakeMix !== true &&
+          !isChangeOutput
         const isOwnOrUnspentRibbon =
-          isUnspent || isSelfSendOutput || isFakeMixOutput
-        const isRemainingBalance =
-          targetNode.localId === CHART_REMAINING_BALANCE_LOCAL_ID
+          isUnspent || isSelfSendOutput || isFakeMixOutput || isChangeOutput
+        const isRemainingBalance = isChangeOutput
         const isCurrentTxMinerFee = targetNode.localId === 'current-minerFee'
         const maxDepthH = Math.max(...nodes.map((n) => n.depthH))
         const isCurrentTx =

--- a/apps/mobile/components/SSSankeyNodes.tsx
+++ b/apps/mobile/components/SSSankeyNodes.tsx
@@ -62,6 +62,10 @@ function SSSankeyNodes({
   showUnspentLabel = true
 }: SSSankeyNodesProps) {
   const customFontManager = useSFProFonts()
+  const labelIconSvg = useSVG(require('@/assets/red-label.svg'))
+  const changeIconSvg = useSVG(require('@/assets/green-change.svg'))
+  const fakeMixIconSvg = useSVG(require('@/assets/green-fake-mix.svg'))
+  const minerFeeIconSvg = useSVG(require('@/assets/red-miner.svg'))
 
   const maxDepth =
     nodes.length === 0 ? 0 : Math.max(...nodes.map((node) => node.depthH))
@@ -178,6 +182,10 @@ function SSSankeyNodes({
             node.ioData?.isFakeMix !== true
           }
           showUnspentLabel={showUnspentLabel}
+          labelIconSvg={labelIconSvg}
+          changeIconSvg={changeIconSvg}
+          fakeMixIconSvg={fakeMixIconSvg}
+          minerFeeIconSvg={minerFeeIconSvg}
         />
       </Group>
     )
@@ -203,7 +211,11 @@ function NodeText({
   isFakeMix,
   isChange: isChangeProp,
   isSelfSend,
-  showUnspentLabel = true
+  showUnspentLabel = true,
+  labelIconSvg,
+  changeIconSvg,
+  fakeMixIconSvg,
+  minerFeeIconSvg
 }: {
   localId: string
   isBlock: boolean
@@ -218,13 +230,17 @@ function NodeText({
   isChange?: boolean
   isSelfSend?: boolean
   showUnspentLabel?: boolean
+  labelIconSvg: ReturnType<typeof useSVG>
+  changeIconSvg: ReturnType<typeof useSVG>
+  fakeMixIconSvg: ReturnType<typeof useSVG>
+  minerFeeIconSvg: ReturnType<typeof useSVG>
 }) {
   const isMiningFee = localId.includes('minerFee')
   const isHigherMinerFee = ioData?.higherFee === true
   const isFeeValueWarning = isHigherMinerFee || ioData?.elevatedFeeRate === true
   const isChange =
     isChangeProp === true || localId === CHART_REMAINING_BALANCE_LOCAL_ID
-  const isUnspent = ioData?.isUnspent
+  const isUnspent = ioData?.isUnspent === true
 
   const shadowPaint = useMemo(() => {
     const paint = Skia.Paint()
@@ -242,11 +258,6 @@ function NodeText({
     )
     return paint
   }, [])
-
-  const labelIconSvg = useSVG(require('@/assets/red-label.svg'))
-  const changeIconSvg = useSVG(require('@/assets/green-change.svg'))
-  const fakeMixIconSvg = useSVG(require('@/assets/green-fake-mix.svg'))
-  const minerFeeIconSvg = useSVG(require('@/assets/red-miner.svg'))
   const blockNodeParagraph = useMemo(() => {
     if (!customFontManager) {
       return null
@@ -612,19 +623,11 @@ function NodeText({
   const groupBaseX = isUnspent ? paragraphX + NODE_MARGIN_LEFT : paragraphX
 
   // Get placeholder rects if it's a mining fee node
-  const placeholderRectsMinerIcon = useMemo(() => {
-    if (isMiningFee && mainParagraph) {
-      return mainParagraph.getRectsForPlaceholders()
-    }
-    return []
-  }, [mainParagraph, isMiningFee])
+  const placeholderRectsMinerIcon =
+    isMiningFee && mainParagraph ? mainParagraph.getRectsForPlaceholders() : []
 
-  const placeholderRectsUnspentIcon = useMemo(() => {
-    if (isUnspent && mainParagraph) {
-      return mainParagraph.getRectsForPlaceholders()
-    }
-    return []
-  }, [mainParagraph, isUnspent])
+  const placeholderRectsUnspentIcon =
+    isUnspent && mainParagraph ? mainParagraph.getRectsForPlaceholders() : []
 
   const dustBorderPaint = useMemo(() => {
     const paint = Skia.Paint()
@@ -640,6 +643,18 @@ function NodeText({
 
   const paragraphActualWidth = isBlock ? width * 0.6 : width - PADDING_LEFT
   const paragraphActualHeight = mainParagraph.getHeight()
+
+  const unspentIconRect = placeholderRectsUnspentIcon[0]?.rect
+  const minerIconRect = placeholderRectsMinerIcon[0]?.rect
+  const fallbackIconY = Math.max(0, paragraphActualHeight - ICON_SIZE - 2)
+  const unspentIconX = groupBaseX + (unspentIconRect?.x ?? 0)
+  const unspentIconY = paragraphY + (unspentIconRect?.y ?? fallbackIconY)
+  const unspentIconW = unspentIconRect?.width ?? ICON_SIZE
+  const unspentIconH = unspentIconRect?.height ?? ICON_SIZE
+  const minerIconX = paragraphX + (minerIconRect?.x ?? 0)
+  const minerIconY = paragraphY + (minerIconRect?.y ?? fallbackIconY)
+  const minerIconW = minerIconRect?.width ?? ICON_SIZE
+  const minerIconH = minerIconRect?.height ?? ICON_SIZE
 
   const isDustOutput =
     isUnspent &&
@@ -696,73 +711,56 @@ function NodeText({
           width={paragraphActualWidth}
         />
       )}
+      {isUnspent && changeIconSvg && isChange ? (
+        <ImageSVG
+          svg={changeIconSvg}
+          x={unspentIconX}
+          y={unspentIconY}
+          width={unspentIconW}
+          height={unspentIconH}
+        />
+      ) : null}
+      {isUnspent && fakeMixIconSvg && isFakeMix ? (
+        <ImageSVG
+          svg={fakeMixIconSvg}
+          x={unspentIconX}
+          y={unspentIconY}
+          width={unspentIconW}
+          height={unspentIconH}
+        />
+      ) : null}
       {isUnspent &&
-        changeIconSvg &&
-        placeholderRectsUnspentIcon.length > 0 &&
-        placeholderRectsUnspentIcon[0] &&
-        isChange && (
-          <ImageSVG
-            svg={changeIconSvg}
-            x={groupBaseX + placeholderRectsUnspentIcon[0].rect.x}
-            y={paragraphY + placeholderRectsUnspentIcon[0].rect.y}
-            width={placeholderRectsUnspentIcon[0].rect.width}
-            height={placeholderRectsUnspentIcon[0].rect.height}
-          />
-        )}
-      {isUnspent &&
-        fakeMixIconSvg &&
-        placeholderRectsUnspentIcon.length > 0 &&
-        placeholderRectsUnspentIcon[0] &&
-        isFakeMix && (
-          <ImageSVG
-            svg={fakeMixIconSvg}
-            x={groupBaseX + placeholderRectsUnspentIcon[0].rect.x}
-            y={paragraphY + placeholderRectsUnspentIcon[0].rect.y}
-            width={placeholderRectsUnspentIcon[0].rect.width}
-            height={placeholderRectsUnspentIcon[0].rect.height}
-          />
-        )}
-      {isUnspent &&
-        labelIconSvg &&
-        placeholderRectsUnspentIcon.length > 0 &&
-        placeholderRectsUnspentIcon[0] &&
-        !isChange &&
-        !isSelfSend &&
-        !isFakeMix &&
-        ioData?.label && (
-          <ImageSVG
-            svg={labelIconSvg}
-            x={groupBaseX + placeholderRectsUnspentIcon[0].rect.x}
-            y={paragraphY + placeholderRectsUnspentIcon[0].rect.y}
-            width={placeholderRectsUnspentIcon[0].rect.width}
-            height={placeholderRectsUnspentIcon[0].rect.height}
-          />
-        )}
-      {isUnspent &&
-        changeIconSvg &&
-        placeholderRectsUnspentIcon.length > 0 &&
-        placeholderRectsUnspentIcon[0] &&
-        isSelfSend && (
-          <ImageSVG
-            svg={changeIconSvg}
-            x={groupBaseX + placeholderRectsUnspentIcon[0].rect.x}
-            y={paragraphY + placeholderRectsUnspentIcon[0].rect.y}
-            width={placeholderRectsUnspentIcon[0].rect.width}
-            height={placeholderRectsUnspentIcon[0].rect.height}
-          />
-        )}
-      {isMiningFee &&
-        minerFeeIconSvg &&
-        placeholderRectsMinerIcon.length > 0 &&
-        placeholderRectsMinerIcon[0] && (
-          <ImageSVG
-            svg={minerFeeIconSvg}
-            x={paragraphX + placeholderRectsMinerIcon[0].rect.x}
-            y={paragraphY + placeholderRectsMinerIcon[0].rect.y}
-            width={placeholderRectsMinerIcon[0].rect.width}
-            height={placeholderRectsMinerIcon[0].rect.height}
-          />
-        )}
+      labelIconSvg &&
+      !isChange &&
+      !isSelfSend &&
+      !isFakeMix &&
+      ioData?.label ? (
+        <ImageSVG
+          svg={labelIconSvg}
+          x={unspentIconX}
+          y={unspentIconY}
+          width={unspentIconW}
+          height={unspentIconH}
+        />
+      ) : null}
+      {isUnspent && changeIconSvg && isSelfSend ? (
+        <ImageSVG
+          svg={changeIconSvg}
+          x={unspentIconX}
+          y={unspentIconY}
+          width={unspentIconW}
+          height={unspentIconH}
+        />
+      ) : null}
+      {isMiningFee && minerFeeIconSvg ? (
+        <ImageSVG
+          svg={minerFeeIconSvg}
+          x={minerIconX}
+          y={minerIconY}
+          width={minerIconW}
+          height={minerIconH}
+        />
+      ) : null}
     </Group>
   )
 }

--- a/apps/mobile/components/SSSankeyNodes.tsx
+++ b/apps/mobile/components/SSSankeyNodes.tsx
@@ -167,9 +167,14 @@ function SSSankeyNodes({
           isTransactionChart={isTransactionChart}
           selectedOutputNode={selectedOutputNode}
           isFakeMix={node.ioData?.isFakeMix === true}
+          isChange={
+            node.ioData?.isChange === true ||
+            node?.localId === CHART_REMAINING_BALANCE_LOCAL_ID
+          }
           isSelfSend={
-            node.ioData?.isSelfSend &&
-            !(node?.localId === CHART_REMAINING_BALANCE_LOCAL_ID) &&
+            node.ioData?.isSelfSend === true &&
+            node.ioData?.isChange !== true &&
+            node?.localId !== CHART_REMAINING_BALANCE_LOCAL_ID &&
             node.ioData?.isFakeMix !== true
           }
           showUnspentLabel={showUnspentLabel}
@@ -196,6 +201,7 @@ function NodeText({
   isTransactionChart,
   selectedOutputNode,
   isFakeMix,
+  isChange: isChangeProp,
   isSelfSend,
   showUnspentLabel = true
 }: {
@@ -209,13 +215,15 @@ function NodeText({
   isTransactionChart: boolean
   selectedOutputNode?: string
   isFakeMix?: boolean
+  isChange?: boolean
   isSelfSend?: boolean
   showUnspentLabel?: boolean
 }) {
   const isMiningFee = localId.includes('minerFee')
   const isHigherMinerFee = ioData?.higherFee === true
   const isFeeValueWarning = isHigherMinerFee || ioData?.elevatedFeeRate === true
-  const isChange = localId === CHART_REMAINING_BALANCE_LOCAL_ID
+  const isChange =
+    isChangeProp === true || localId === CHART_REMAINING_BALANCE_LOCAL_ID
   const isUnspent = ioData?.isUnspent
 
   const shadowPaint = useMemo(() => {

--- a/apps/mobile/components/SSTransactionChart.tsx
+++ b/apps/mobile/components/SSTransactionChart.tsx
@@ -16,11 +16,7 @@ import {
   SANKEY_EQUAL_ROW_MIN_SLOT_PX,
   SAFE_LIMIT_OF_INPUTS_OUTPUTS
 } from '@/types/ui/sankey'
-import {
-  isChangeOutputAddress,
-  isChangeOutputLabel,
-  normalizeAddressSet
-} from '@/utils/address'
+import { isChangeOutputAddress, normalizeAddressSet } from '@/utils/address'
 import {
   equalizeSankeyColumnsByDepthH,
   minSankeyStackedColumnInnerHeightPx
@@ -28,6 +24,7 @@ import {
 import { getFeePercentage, isHighMinerFee } from '@/utils/feeWarnings'
 import { formatAddress, formatNumber } from '@/utils/format'
 import { buildSankeyRibbonPlan } from '@/utils/sankeyFlowWidths'
+import { classifyChartOutput } from '@/utils/stonewall'
 
 import { withPerformanceWarning } from './SSPerformanceWarning'
 import SSSankeyLinks from './SSSankeyLinks'
@@ -98,6 +95,7 @@ function SSTransactionChart({
 
   const outputs = transaction.vout.map((output) => ({
     address: output.address,
+    kind: output.kind,
     label: output.label || '',
     value: output.value
   }))
@@ -212,16 +210,24 @@ function SSTransactionChart({
       const nodeId = String(index + 2 + inputs.length)
       const label = output.label ?? ''
       const outputAddress = output.address.trim()
-      const isChange =
-        isChangeOutputAddress(outputAddress, normalizedInternalAddresses) ||
-        isChangeOutputLabel(label)
+      const { isChange, isFakeMix, isSelfSend } = classifyChartOutput(
+        {
+          kind: output.kind,
+          label,
+          localId: `output-${index}`,
+          to: outputAddress
+        },
+        normalizedOwnAddresses
+      )
+      // Fake-mix uses an unused internal address — never treat it as change.
+      const isChangeOutput =
+        !isFakeMix &&
+        (isChange ||
+          isChangeOutputAddress(outputAddress, normalizedInternalAddresses))
       const isUnspent = unspentOutpoints
         ? unspentOutpoints.has(`${transaction.id}:${index}`)
         : true
-      const isSelfSend =
-        !isChange &&
-        outputAddress !== '' &&
-        normalizedOwnAddresses.has(outputAddress)
+      const isSelfSendOutput = !isChangeOutput && !isFakeMix && isSelfSend
 
       return {
         depthH: 2,
@@ -230,7 +236,9 @@ function SSTransactionChart({
           address: formatAddress(output.address, 6),
           fiatCurrency,
           fiatValue: formatNumber(satsToFiat(output.value), 2),
-          isSelfSend,
+          isChange: isChangeOutput,
+          isFakeMix,
+          isSelfSend: isSelfSendOutput,
           isUnspent,
           label: label || t('common.noLabel'),
           text: isUnspent
@@ -238,7 +246,7 @@ function SSTransactionChart({
             : t('transaction.build.spent'),
           value: output.value
         },
-        localId: isChange ? 'remainingBalance' : `output-${index}`,
+        localId: `output-${index}`,
         type: 'text',
         value: output.value
       }

--- a/apps/mobile/hooks/useNodesAndLinks.ts
+++ b/apps/mobile/hooks/useNodesAndLinks.ts
@@ -8,7 +8,10 @@ import { type Utxo } from '@/types/models/Utxo'
 import { formatDate, formatRelativeTime } from '@/utils/date'
 import { getFeePercentage, isHighMinerFee } from '@/utils/feeWarnings'
 import { formatAddress, formatNumber, formatTxId } from '@/utils/format'
-import { CHART_REMAINING_BALANCE_LOCAL_ID } from '@/utils/stonewall'
+import {
+  CHART_REMAINING_BALANCE_LOCAL_ID,
+  classifyChartOutput
+} from '@/utils/stonewall'
 import { estimateTransactionSize } from '@/utils/transaction'
 import { getUtxoOutpoint } from '@/utils/utxo'
 
@@ -46,6 +49,7 @@ export type TxNode = {
     elevatedFeeRate?: boolean // fee rate is at least 2x the recommended next-block fee
     feePercentage?: number // miner fee is 10% or higher of the total transaction value
     isFakeMix?: boolean
+    isChange?: boolean
     isSelfSend?: boolean // NEW: flag for self-send
     maxAllowedSats?: number
   }
@@ -116,8 +120,7 @@ export const useNodesAndLinks = ({
           address: formatAddress(output.to, 4),
           fiatCurrency,
           fiatValue: formatNumber(satsToFiat(output.amount), 2),
-          isFakeMix: output.kind === 'fakeMix',
-          isSelfSend: output.kind !== 'fakeMix' && ownAddresses.has(output.to),
+          ...classifyChartOutput(output, ownAddresses),
           isUnspent: true,
           label: output.label,
           text: t('transaction.build.unspent'),
@@ -139,6 +142,7 @@ export const useNodesAndLinks = ({
           ioData: {
             fiatCurrency,
             fiatValue: formatNumber(satsToFiat(remainingBalance), 2),
+            isChange: true,
             isUnspent: true,
             text: t('transaction.build.unspent'),
             value: remainingBalance

--- a/apps/mobile/store/transactionBuilder.ts
+++ b/apps/mobile/store/transactionBuilder.ts
@@ -5,12 +5,33 @@ import { createJSONStorage, persist } from 'zustand/middleware'
 import { immer } from 'zustand/middleware/immer'
 
 import mmkvStorage from '@/storage/mmkv'
+import { type AutoSelectUtxosAlgorithm } from '@/types/models/AutoSelectUtxos'
 import { type Output } from '@/types/models/Output'
 import { type Utxo } from '@/types/models/Utxo'
 import { randomUuid } from '@/utils/crypto'
+import {
+  DEFAULT_AUTO_SELECT,
+  resolveDraftAlgorithm
+} from '@/utils/draftSelection'
 import { getUtxoOutpoint } from '@/utils/utxo'
 
 enableMapSet()
+
+type StonewallPreviewState = {
+  changeValues: number[]
+  excludedUtxoOutpoints: string[]
+  fakeMixValues: number[]
+  fee: number | null
+  labelOverrides: Record<string, string>
+}
+
+const EMPTY_STONEWALL_PREVIEW: StonewallPreviewState = {
+  changeValues: [],
+  excludedUtxoOutpoints: [],
+  fakeMixValues: [],
+  fee: null,
+  labelOverrides: {}
+}
 
 type SavedDraft = {
   inputs: Record<string, Utxo>
@@ -20,6 +41,9 @@ type SavedDraft = {
   timeLock: number
   rbf: boolean
   cpfp: boolean
+  /** Last applied UTXO selection mode — defaults to 'user' for older drafts. */
+  selectedAutoSelectUtxos?: AutoSelectUtxosAlgorithm
+  stonewallPreview?: StonewallPreviewState
 }
 
 type TransactionBuilderState = {
@@ -31,6 +55,8 @@ type TransactionBuilderState = {
   timeLock: number
   rbf: boolean
   cpfp: boolean
+  selectedAutoSelectUtxos: AutoSelectUtxosAlgorithm
+  stonewallPreview: StonewallPreviewState
   psbt?: PsbtLike
   signedTx?: string
   signedPsbts: Map<number, string>
@@ -56,6 +82,9 @@ type TransactionBuilderAction = {
   setFeeRate: (feeRate: TransactionBuilderState['feeRate']) => void
   setFee: (fee: TransactionBuilderState['fee']) => void
   setRbf: (rbf: TransactionBuilderState['rbf']) => void
+  setSelectedAutoSelectUtxos: (algorithm: AutoSelectUtxosAlgorithm) => void
+  setStonewallPreview: (preview: Partial<StonewallPreviewState>) => void
+  clearStonewallPreview: () => void
   setPsbt: (psbt: NonNullable<TransactionBuilderState['psbt']>) => void
   setSignedTx: (
     signedTx: NonNullable<TransactionBuilderState['signedTx']>
@@ -64,10 +93,27 @@ type TransactionBuilderAction = {
   setBroadcasted: (broadcasted: boolean) => void
 }
 
+function normalizeStonewallPreview(
+  preview?: StonewallPreviewState
+): StonewallPreviewState {
+  if (!preview) {
+    return { ...EMPTY_STONEWALL_PREVIEW, labelOverrides: {} }
+  }
+  return {
+    changeValues: preview.changeValues ?? [],
+    excludedUtxoOutpoints: preview.excludedUtxoOutpoints ?? [],
+    fakeMixValues: preview.fakeMixValues ?? [],
+    fee: preview.fee ?? null,
+    labelOverrides: { ...(preview.labelOverrides ?? {}) }
+  }
+}
+
 function syncDraft(state: Draft<TransactionBuilderState>) {
   if (!state.accountId) {
     return
   }
+  // Avoid current(stonewallPreview): after replace it may be a plain object.
+  const preview = state.stonewallPreview
   state.drafts[state.accountId] = {
     cpfp: state.cpfp,
     fee: state.fee,
@@ -75,6 +121,14 @@ function syncDraft(state: Draft<TransactionBuilderState>) {
     inputs: Object.fromEntries(current(state.inputs)),
     outputs: current(state.outputs),
     rbf: state.rbf,
+    selectedAutoSelectUtxos: state.selectedAutoSelectUtxos,
+    stonewallPreview: {
+      changeValues: [...preview.changeValues],
+      excludedUtxoOutpoints: [...preview.excludedUtxoOutpoints],
+      fakeMixValues: [...preview.fakeMixValues],
+      fee: preview.fee,
+      labelOverrides: { ...preview.labelOverrides }
+    },
     timeLock: state.timeLock
   }
 }
@@ -101,6 +155,12 @@ const useTransactionBuilderStore = create<
       clearPsbt: () => {
         set({ psbt: undefined })
       },
+      clearStonewallPreview: () => {
+        set((state) => {
+          state.stonewallPreview = normalizeStonewallPreview()
+          syncDraft(state)
+        })
+      },
       clearTransaction: () => {
         const { accountId, drafts } = get()
         const updatedDrafts = { ...drafts }
@@ -118,8 +178,10 @@ const useTransactionBuilderStore = create<
           outputs: [],
           psbt: undefined,
           rbf: true,
+          selectedAutoSelectUtxos: DEFAULT_AUTO_SELECT,
           signedPsbts: new Map<number, string>(),
           signedTx: undefined,
+          stonewallPreview: normalizeStonewallPreview(),
           timeLock: 0
         })
       },
@@ -160,6 +222,7 @@ const useTransactionBuilderStore = create<
           syncDraft(state)
         })
       },
+      selectedAutoSelectUtxos: DEFAULT_AUTO_SELECT,
       setAccountId: (accountId) => {
         const {
           accountId: currentId,
@@ -170,7 +233,9 @@ const useTransactionBuilderStore = create<
           timeLock,
           rbf,
           cpfp,
-          drafts
+          drafts,
+          selectedAutoSelectUtxos,
+          stonewallPreview
         } = get()
 
         if (currentId === accountId) {
@@ -187,6 +252,8 @@ const useTransactionBuilderStore = create<
             inputs: Object.fromEntries(inputs),
             outputs: [...outputs],
             rbf,
+            selectedAutoSelectUtxos,
+            stonewallPreview: normalizeStonewallPreview(stonewallPreview),
             timeLock
           }
         }
@@ -205,8 +272,12 @@ const useTransactionBuilderStore = create<
           outputs: newDraft?.outputs ?? [],
           psbt: undefined,
           rbf: newDraft?.rbf ?? true,
+          selectedAutoSelectUtxos: resolveDraftAlgorithm(newDraft),
           signedPsbts: new Map<number, string>(),
           signedTx: undefined,
+          stonewallPreview: normalizeStonewallPreview(
+            newDraft?.stonewallPreview
+          ),
           timeLock: newDraft?.timeLock ?? 0
         })
       },
@@ -234,13 +305,33 @@ const useTransactionBuilderStore = create<
           syncDraft(state)
         })
       },
+      setSelectedAutoSelectUtxos: (algorithm) => {
+        set((state) => {
+          state.selectedAutoSelectUtxos = algorithm
+          syncDraft(state)
+        })
+      },
       setSignedPsbts: (signedPsbts) => {
         set({ signedPsbts })
       },
       setSignedTx: (signedTx) => {
         set({ signedTx })
       },
+      setStonewallPreview: (preview) => {
+        set((state) => {
+          state.stonewallPreview = {
+            ...state.stonewallPreview,
+            ...preview,
+            labelOverrides:
+              preview.labelOverrides !== undefined
+                ? preview.labelOverrides
+                : state.stonewallPreview.labelOverrides
+          }
+          syncDraft(state)
+        })
+      },
       signedPsbts: new Map<number, string>(),
+      stonewallPreview: normalizeStonewallPreview(),
       timeLock: 0,
       updateOutput: (localId, output) => {
         set((state) => {
@@ -271,6 +362,8 @@ const useTransactionBuilderStore = create<
           inputs: new Map(Object.entries(draft.inputs)),
           outputs: draft.outputs,
           rbf: draft.rbf,
+          selectedAutoSelectUtxos: resolveDraftAlgorithm(draft),
+          stonewallPreview: normalizeStonewallPreview(draft.stonewallPreview),
           timeLock: draft.timeLock
         })
       },
@@ -284,4 +377,4 @@ const useTransactionBuilderStore = create<
 )
 
 export { useTransactionBuilderStore }
-export type { SavedDraft }
+export type { SavedDraft, StonewallPreviewState }

--- a/apps/mobile/tests/unit/utils/draftSelection.test.ts
+++ b/apps/mobile/tests/unit/utils/draftSelection.test.ts
@@ -1,0 +1,120 @@
+import { getDraftIoCounts, resolveDraftAlgorithm } from '@/utils/draftSelection'
+
+describe('resolveDraftAlgorithm', () => {
+  it('returns the persisted algorithm when present', () => {
+    expect(
+      resolveDraftAlgorithm({
+        outputs: [],
+        selectedAutoSelectUtxos: 'efficiency'
+      })
+    ).toBe('efficiency')
+  })
+
+  it('infers privacy from stonewall-managed outputs on legacy drafts', () => {
+    expect(
+      resolveDraftAlgorithm({
+        outputs: [
+          {
+            kind: 'fakeMix'
+          }
+        ]
+      })
+    ).toBe('privacy')
+
+    expect(
+      resolveDraftAlgorithm({
+        outputs: [
+          {
+            kind: 'change'
+          }
+        ]
+      })
+    ).toBe('privacy')
+  })
+
+  it('defaults to user when nothing was applied', () => {
+    expect(resolveDraftAlgorithm(undefined)).toBe('user')
+    expect(resolveDraftAlgorithm({ outputs: [] })).toBe('user')
+    expect(
+      resolveDraftAlgorithm({
+        outputs: [{ kind: undefined }]
+      })
+    ).toBe('user')
+  })
+})
+
+describe('getDraftIoCounts', () => {
+  it('returns zeros for a missing draft', () => {
+    expect(getDraftIoCounts(undefined)).toStrictEqual({
+      inputCount: 0,
+      outputCount: 0
+    })
+  })
+
+  it('counts store inputs and outputs for a simple draft', () => {
+    expect(
+      getDraftIoCounts({
+        fee: 200,
+        inputs: {
+          'a:0': { value: 10_000 },
+          'b:1': { value: 5_000 }
+        },
+        outputs: [{ amount: 14_800, kind: undefined }]
+      })
+    ).toStrictEqual({ inputCount: 2, outputCount: 1 })
+  })
+
+  it('includes impending change when remaining balance is positive', () => {
+    expect(
+      getDraftIoCounts({
+        fee: 500,
+        inputs: {
+          'a:0': { value: 20_000 }
+        },
+        outputs: [{ amount: 10_000, kind: undefined }],
+        selectedAutoSelectUtxos: 'user'
+      })
+    ).toStrictEqual({ inputCount: 1, outputCount: 2 })
+  })
+
+  it('includes stonewall preview outputs for privacy drafts', () => {
+    expect(
+      getDraftIoCounts({
+        fee: 1_000,
+        inputs: {
+          'a:0': { value: 50_000 },
+          'b:0': { value: 40_000 },
+          'c:0': { value: 30_000 },
+          'd:0': { value: 20_000 }
+        },
+        outputs: [{ amount: 25_000, kind: undefined }],
+        selectedAutoSelectUtxos: 'privacy',
+        stonewallPreview: {
+          changeValues: [30_000, 20_000],
+          fakeMixValues: [24_000]
+        }
+      })
+    ).toStrictEqual({ inputCount: 4, outputCount: 4 })
+  })
+
+  it('does not double-count materialized stonewall outputs', () => {
+    expect(
+      getDraftIoCounts({
+        fee: 1_000,
+        inputs: {
+          'a:0': { value: 50_000 }
+        },
+        outputs: [
+          { amount: 25_000, kind: undefined },
+          { amount: 24_000, kind: 'fakeMix' },
+          { amount: 0, kind: 'change' }
+        ],
+        selectedAutoSelectUtxos: 'privacy',
+        stonewallPreview: {
+          changeValues: [30_000],
+          fakeMixValues: [24_000]
+        }
+      })
+    ).toStrictEqual({ inputCount: 1, outputCount: 3 })
+  })
+})

--- a/apps/mobile/tests/unit/utils/stonewall.test.ts
+++ b/apps/mobile/tests/unit/utils/stonewall.test.ts
@@ -3,9 +3,85 @@ import {
   buildStonewallMaterializationPlan,
   buildStonewallPreviewOutputs,
   CHART_REMAINING_BALANCE_LOCAL_ID,
+  classifyChartOutput,
+  getEphemeralChangeOutputLocalIds,
   getStonewallPaymentContext
 } from '@/utils/stonewall'
 import { splitStonewallOutputValues } from '@/utils/utxo'
+
+describe('classifyChartOutput', () => {
+  const own = new Set(['bc1qown', 'bc1qchange', 'bc1qdecoy'])
+
+  it('marks fake-mix outputs', () => {
+    expect(
+      classifyChartOutput(
+        {
+          kind: 'fakeMix',
+          label: 'Coffee',
+          localId: 'stonewallFakeMix-0',
+          to: 'bc1qdecoy'
+        },
+        own
+      )
+    ).toStrictEqual({
+      isChange: false,
+      isFakeMix: true,
+      isSelfSend: false
+    })
+  })
+
+  it('marks change outputs by kind even when address is wallet-owned', () => {
+    expect(
+      classifyChartOutput(
+        {
+          kind: 'change',
+          label: 'Change',
+          localId: 'stonewallChange-0',
+          to: 'bc1qchange'
+        },
+        own
+      )
+    ).toStrictEqual({
+      isChange: true,
+      isFakeMix: false,
+      isSelfSend: false
+    })
+  })
+
+  it('marks self-sends to own addresses that are not change', () => {
+    expect(
+      classifyChartOutput(
+        {
+          label: 'Refund',
+          localId: 'out-1',
+          to: 'bc1qown'
+        },
+        own
+      )
+    ).toStrictEqual({
+      isChange: false,
+      isFakeMix: false,
+      isSelfSend: true
+    })
+  })
+
+  it('marks external recipients as spends', () => {
+    expect(
+      classifyChartOutput(
+        {
+          label: 'Merchant',
+          localId: 'out-2',
+          to: 'bc1qexternal'
+        },
+        own
+      )
+    ).toStrictEqual({
+      isChange: false,
+      isFakeMix: false,
+      isSelfSend: false
+    })
+  })
+})
 
 describe('buildStonewallPreviewOutputs', () => {
   it('returns empty when fee is null', () => {
@@ -42,14 +118,34 @@ describe('buildStonewallPreviewOutputs', () => {
     })
     expect(outputs[1]).toMatchObject({
       amount: 1000,
+      kind: 'change',
       localId: 'stonewallChange-0',
       to: 'bc1qchange1'
     })
     expect(outputs[2]).toMatchObject({
       amount: 2000,
+      kind: 'change',
       localId: 'stonewallChange-1',
       to: 'bc1qchange2'
     })
+  })
+
+  it('applies label overrides to preview outputs', () => {
+    const outputs = buildStonewallPreviewOutputs({
+      changeAddress: 'bc1qchange1',
+      changeValues: [1000],
+      decoyAddress: 'bc1qdecoy',
+      fakeMixLabel: 'Coffee shop',
+      fakeMixValues: [500],
+      fee: 678,
+      labelOverrides: {
+        'stonewallChange-0': 'Savings',
+        'stonewallFakeMix-0': 'Decoy'
+      }
+    })
+
+    expect(outputs[0].label).toBe('Decoy')
+    expect(outputs[1].label).toBe('Savings')
   })
 })
 
@@ -76,6 +172,7 @@ describe('buildStonewallMaterializationPlan', () => {
         },
         {
           amount: 1_000,
+          kind: 'change',
           label: 'Change',
           to: 'bc1qchange1'
         }
@@ -164,5 +261,52 @@ describe('splitStonewallOutputValues', () => {
       changeValues: [200, 300],
       fakeMixValues: [100]
     })
+  })
+})
+
+describe('getEphemeralChangeOutputLocalIds', () => {
+  it('returns stonewall-managed and change-address output ids', () => {
+    expect(
+      getEphemeralChangeOutputLocalIds(
+        [
+          {
+            kind: undefined,
+            localId: 'payment',
+            to: 'bc1qrecipient'
+          },
+          {
+            kind: 'fakeMix',
+            localId: 'stonewallFakeMix-0',
+            to: 'bc1qdecoy'
+          },
+          {
+            kind: 'change',
+            localId: 'stonewallChange-0',
+            to: 'bc1qchange'
+          },
+          {
+            kind: undefined,
+            localId: 'user-change',
+            to: 'bc1qchange2'
+          }
+        ],
+        ['bc1qchange', 'bc1qchange2', 'bc1qdecoy']
+      )
+    ).toStrictEqual(['stonewallFakeMix-0', 'stonewallChange-0', 'user-change'])
+  })
+
+  it('ignores undefined change addresses and payment outputs', () => {
+    expect(
+      getEphemeralChangeOutputLocalIds(
+        [
+          {
+            kind: undefined,
+            localId: 'payment',
+            to: 'bc1qrecipient'
+          }
+        ],
+        [undefined, undefined]
+      )
+    ).toStrictEqual([])
   })
 })

--- a/apps/mobile/types/models/Output.ts
+++ b/apps/mobile/types/models/Output.ts
@@ -1,4 +1,4 @@
-export type OutputKind = 'fakeMix'
+export type OutputKind = 'fakeMix' | 'change'
 
 export type Output = {
   localId: string

--- a/apps/mobile/types/models/Transaction.ts
+++ b/apps/mobile/types/models/Transaction.ts
@@ -34,6 +34,7 @@ export const TransactionSchema = z.object({
   vout: z.array(
     z.object({
       address: z.string(),
+      kind: z.enum(['fakeMix', 'change']).optional(),
       label: z.string().optional(),
       script: z.union([z.array(z.number()), z.string()]),
       value: z.number()

--- a/apps/mobile/utils/draftSelection.ts
+++ b/apps/mobile/utils/draftSelection.ts
@@ -1,0 +1,89 @@
+import { type AutoSelectUtxosAlgorithm } from '@/types/models/AutoSelectUtxos'
+import { type Output } from '@/types/models/Output'
+import { type Utxo } from '@/types/models/Utxo'
+
+const DEFAULT_AUTO_SELECT: AutoSelectUtxosAlgorithm = 'user'
+
+type DraftAlgorithmSource = {
+  outputs?: Pick<Output, 'kind'>[]
+  selectedAutoSelectUtxos?: AutoSelectUtxosAlgorithm
+}
+
+type DraftIoSource = {
+  fee?: number
+  inputs?: Record<string, Pick<Utxo, 'value'>>
+  outputs?: Pick<Output, 'amount' | 'kind'>[]
+  selectedAutoSelectUtxos?: AutoSelectUtxosAlgorithm
+  stonewallPreview?: {
+    changeValues?: number[]
+    fakeMixValues?: number[]
+  }
+}
+
+/**
+ * Resolve the UTXO selection algorithm for a saved draft.
+ * Legacy drafts without `selectedAutoSelectUtxos` infer privacy from stonewall outputs.
+ */
+function resolveDraftAlgorithm(
+  draft?: DraftAlgorithmSource
+): AutoSelectUtxosAlgorithm {
+  if (draft?.selectedAutoSelectUtxos) {
+    return draft.selectedAutoSelectUtxos
+  }
+  if (
+    draft?.outputs?.some(
+      (output) => output.kind === 'fakeMix' || output.kind === 'change'
+    )
+  ) {
+    return 'privacy'
+  }
+  return DEFAULT_AUTO_SELECT
+}
+
+/** Draft card I/O counts, including stonewall preview and impending change. */
+function getDraftIoCounts(draft?: DraftIoSource): {
+  inputCount: number
+  outputCount: number
+} {
+  if (!draft) {
+    return { inputCount: 0, outputCount: 0 }
+  }
+
+  const inputs = draft.inputs ?? {}
+  const outputs = draft.outputs ?? []
+  const inputCount = Object.keys(inputs).length
+  const algorithm = resolveDraftAlgorithm(draft)
+  const hasMaterializedStonewall = outputs.some(
+    (output) => output.kind === 'fakeMix' || output.kind === 'change'
+  )
+
+  if (algorithm === 'privacy' && !hasMaterializedStonewall) {
+    const previewExtra =
+      (draft.stonewallPreview?.changeValues?.length ?? 0) +
+      (draft.stonewallPreview?.fakeMixValues?.length ?? 0)
+    if (previewExtra > 0) {
+      return {
+        inputCount,
+        outputCount: outputs.length + previewExtra
+      }
+    }
+  }
+
+  if (hasMaterializedStonewall) {
+    return { inputCount, outputCount: outputs.length }
+  }
+
+  const inputTotal = Object.values(inputs).reduce(
+    (sum, utxo) => sum + utxo.value,
+    0
+  )
+  const outputTotal = outputs.reduce((sum, output) => sum + output.amount, 0)
+  const remaining = inputTotal - outputTotal - (draft.fee ?? 0)
+  if (remaining > 0) {
+    return { inputCount, outputCount: outputs.length + 1 }
+  }
+
+  return { inputCount, outputCount: outputs.length }
+}
+
+export { DEFAULT_AUTO_SELECT, getDraftIoCounts, resolveDraftAlgorithm }

--- a/apps/mobile/utils/stonewall.ts
+++ b/apps/mobile/utils/stonewall.ts
@@ -2,7 +2,7 @@ import { t } from '@/locales'
 import { type Address } from '@/types/models/Address'
 import { type Output } from '@/types/models/Output'
 import { type ScriptVersionType } from '@/types/models/Script'
-import { getScriptVersionType } from '@/utils/address'
+import { getScriptVersionType, isChangeOutputLabel } from '@/utils/address'
 import {
   mapStonewallChangeOutputs,
   mapStonewallFakeMixOutputs
@@ -40,6 +40,7 @@ type StonewallPreviewParams = {
   fakeMixLabel?: string
   fakeMixValues: number[]
   fee: number | null
+  labelOverrides?: Record<string, string>
   secondChangeAddress?: string
 }
 
@@ -67,6 +68,7 @@ type StonewallMaterializationParams = {
   fakeMixLabel: string
   fakeMixValues: number[]
   fee: number | null
+  labelOverrides?: Record<string, string>
   secondChangeAddress?: string
 }
 
@@ -76,6 +78,78 @@ function stonewallFakeMixLocalId(index: number) {
 
 function stonewallChangeLocalId(index: number) {
   return `${STONEWALL_CHANGE_LOCAL_ID_PREFIX}-${index}`
+}
+
+function isStonewallPreviewLocalId(localId?: string) {
+  if (!localId) {
+    return false
+  }
+  return (
+    localId.startsWith(STONEWALL_FAKE_MIX_LOCAL_ID_PREFIX) ||
+    localId.startsWith(STONEWALL_CHANGE_LOCAL_ID_PREFIX)
+  )
+}
+
+function isStonewallManagedOutput(
+  output: Pick<Output, 'kind' | 'localId'> | undefined
+) {
+  if (!output) {
+    return false
+  }
+  return (
+    output.kind === 'fakeMix' ||
+    output.kind === 'change' ||
+    isStonewallPreviewLocalId(output.localId)
+  )
+}
+
+/** Local IDs of change / stonewall outputs to strip when returning to IO preview. */
+function getEphemeralChangeOutputLocalIds(
+  outputs: Pick<Output, 'kind' | 'localId' | 'to'>[],
+  changeAddresses: (string | undefined)[]
+): string[] {
+  const addressSet = new Set<string>()
+  for (const address of changeAddresses) {
+    if (address) {
+      addressSet.add(address)
+    }
+  }
+
+  const localIds: string[] = []
+  for (const output of outputs) {
+    if (
+      output.kind === 'fakeMix' ||
+      output.kind === 'change' ||
+      addressSet.has(output.to)
+    ) {
+      localIds.push(output.localId)
+    }
+  }
+  return localIds
+}
+
+type ChartOutputFlags = {
+  isChange: boolean
+  isFakeMix: boolean
+  isSelfSend: boolean
+}
+
+function classifyChartOutput(
+  output: Pick<Output, 'kind' | 'label' | 'localId'> & {
+    to?: string
+  },
+  ownAddresses: Set<string>
+): ChartOutputFlags {
+  const isFakeMix = output.kind === 'fakeMix'
+  const isChange =
+    !isFakeMix &&
+    (output.kind === 'change' ||
+      output.localId === CHART_REMAINING_BALANCE_LOCAL_ID ||
+      isChangeOutputLabel(output.label ?? ''))
+  const isSelfSend =
+    !isFakeMix && !isChange && !!output.to && ownAddresses.has(output.to.trim())
+
+  return { isChange, isFakeMix, isSelfSend }
 }
 
 export function getStonewallPaymentContext(
@@ -129,13 +203,15 @@ export function buildStonewallPreviewOutputs(
   }
 
   const previewOutputs: Output[] = []
+  const overrides = params.labelOverrides ?? {}
 
   for (const [index, amount] of params.fakeMixValues.entries()) {
+    const localId = stonewallFakeMixLocalId(index)
     previewOutputs.push({
       amount,
       kind: 'fakeMix',
-      label: params.fakeMixLabel ?? '',
-      localId: stonewallFakeMixLocalId(index),
+      label: overrides[localId] ?? params.fakeMixLabel ?? '',
+      localId,
       to: params.decoyAddress
     })
   }
@@ -150,10 +226,12 @@ export function buildStonewallPreviewOutputs(
     if (!to) {
       continue
     }
+    const localId = stonewallChangeLocalId(index)
     previewOutputs.push({
       amount,
-      label: t('sign.changeAddressLabelDefault'),
-      localId: stonewallChangeLocalId(index),
+      kind: 'change',
+      label: overrides[localId] ?? t('sign.changeAddressLabelDefault'),
+      localId,
       to
     })
   }
@@ -193,22 +271,26 @@ export function buildStonewallMaterializationPlan(
     params.changeValues,
     changeAddresses
   )
+  const overrides = params.labelOverrides ?? {}
 
   const outputs: StonewallMaterializationPlan['outputs'] = []
 
-  for (const output of fakeMixOutputs) {
+  for (const [index, output] of fakeMixOutputs.entries()) {
+    const localId = stonewallFakeMixLocalId(index)
     outputs.push({
       amount: output.amount,
       kind: 'fakeMix',
-      label: params.fakeMixLabel,
+      label: overrides[localId] ?? params.fakeMixLabel,
       to: output.to
     })
   }
 
-  for (const output of changeOutputs) {
+  for (const [index, output] of changeOutputs.entries()) {
+    const localId = stonewallChangeLocalId(index)
     outputs.push({
       amount: output.amount,
-      label: t('sign.changeAddressLabelDefault'),
+      kind: 'change',
+      label: overrides[localId] ?? t('sign.changeAddressLabelDefault'),
       to: output.to
     })
   }
@@ -231,6 +313,7 @@ export function buildSingleTxChartOutputs(
   if (params.remainingBalance > 0) {
     chartOutputs.push({
       amount: params.remainingBalance,
+      kind: 'change',
       label: '',
       localId: CHART_REMAINING_BALANCE_LOCAL_ID,
       to: params.changeAddress
@@ -238,4 +321,11 @@ export function buildSingleTxChartOutputs(
   }
 
   return chartOutputs
+}
+
+export {
+  classifyChartOutput,
+  getEphemeralChangeOutputLocalIds,
+  isStonewallManagedOutput,
+  isStonewallPreviewLocalId
 }


### PR DESCRIPTION
## Summary
- Persist the last-applied UTXO algorithm and stonewall preview on drafts, and restore them in IO preview (including a focus-only strip so continue keeps the full privacy tx)
- Classify privacy change / fake-mix outputs as wallet-owned on IO and preview charts (green fake-mix, white sankey), and pass `kind` through transaction vouts
- Fix draft card input/output counts to include stonewall preview and impending change; load sankey icons once per chart to avoid missing icons on preview

## Test plan
- [ ] Select privacy algo, continue to preview — outputs match IO preview (payment + change + fake-mix), not a single payment with huge fee
- [ ] On preview chart, fake-mix shows green fake-mix label/icon; change/self-send white; sankey ribbons white for those outputs
- [ ] Chart icons (change, fake-mix, label, miner fee) render on preview
- [ ] Leave mid-build, reopen account — draft card I/O counts match the chart; reopening IO preview restores privacy algo + selection
- [ ] Discard draft removes the card; broadcast / discard clears the draft as before