### PR TITLE
Fix: Decrypt Key Secrets of Accounts loaded from Database

### DIFF
--- a/.claude/rules/best-practices.md
+++ b/.claude/rules/best-practices.md
@@ -5,6 +5,7 @@ paths:
 
 # Best Practices
 
+0. Don't add irrelevant comments. Code should speak for itself. Add comments only when strictly necessary to explain the code that follows.
 1. Avoid using `useEffect`;
 2. We are using react-compiler, so avoid using `useMemo`, `memo`, and `useCallback`;
 3. Avoid duplicating code. Use or create `util`, `api`, or `store` functions;

--- a/apps/mobile/db/mappers.ts
+++ b/apps/mobile/db/mappers.ts
@@ -210,7 +210,7 @@ function rowToAccount(
     id: row.id,
     keyCount: row.key_count,
     keys: parseJson<KeyMeta[]>(row.keys, []).map(
-      (meta): Key => ({ ...meta, iv: '', secret: '' })
+      (meta): Key => ({ ...meta, accountId: row.id, iv: '', secret: '' })
     ),
     keysRequired: row.keys_required,
     labels,

--- a/apps/mobile/db/mutations/accounts.ts
+++ b/apps/mobile/db/mutations/accounts.ts
@@ -13,7 +13,9 @@ import { upsertUtxos } from './utxos'
 type TransactionContext = NitroSQLiteConnection
 
 function keysToJson(keys: Key[]): string {
-  return JSON.stringify(keys.map(({ secret: _s, iv: _iv, ...meta }) => meta))
+  return JSON.stringify(
+    keys.map(({ secret: _s, iv: _iv, accountId: _a, ...meta }) => meta)
+  )
 }
 
 function insertAccount(account: Account) {

--- a/apps/mobile/tests/unit/utils/decryption.test.ts
+++ b/apps/mobile/tests/unit/utils/decryption.test.ts
@@ -155,6 +155,24 @@ describe('decryptKeySecretUsingPin', () => {
     const secret = await decryptKeySecretUsingPin(key, '1234')
     expect(secret).toStrictEqual({ mnemonic: 'w' })
   })
+
+  it('falls back to secure storage when the secret is empty and accountId is set', async () => {
+    getKeySecret.mockResolvedValue({ iv: 'stored-iv', secret: 'stored-enc' })
+    aesDecrypt.mockResolvedValue(JSON.stringify({ mnemonic: 'word1 word2' }))
+    const key = makeKey({ accountId: 'acc-1', index: 2 })
+    const secret = await decryptKeySecretUsingPin(key, '1234')
+    expect(getKeySecret).toHaveBeenCalledWith('acc-1', 2)
+    expect(aesDecrypt).toHaveBeenCalledWith('stored-enc', '1234', 'stored-iv')
+    expect(secret).toStrictEqual({ mnemonic: 'word1 word2' })
+  })
+
+  it('throws when the secret is empty and there is no accountId', async () => {
+    const key = makeKey()
+    await expect(decryptKeySecretUsingPin(key, '1234')).rejects.toThrow(
+      'Key secret not available'
+    )
+    expect(aesDecrypt).not.toHaveBeenCalled()
+  })
 })
 
 describe('decryptKeySecretAt', () => {

--- a/apps/mobile/types/models/Account.ts
+++ b/apps/mobile/types/models/Account.ts
@@ -59,6 +59,8 @@ export const KeyMetaSchema = z.object({
 })
 
 export const KeySchema = KeyMetaSchema.extend({
+  /** Set on DB load, stripped on DB write. */
+  accountId: z.string().optional(),
   iv: z.string(),
   secret: z.union([SecretSchema, z.string()])
 })

--- a/apps/mobile/utils/decryption.ts
+++ b/apps/mobile/utils/decryption.ts
@@ -32,7 +32,7 @@ export async function decryptAccountKeySecretUsingPin(
   if (!stored) {
     throw new Error(`Key secret not found in secure storage (key #${keyIndex})`)
   }
-  return decryptKeySecretUsingPin(stored as Key, pin)
+  return decryptKeySecretUsingPin(stored, pin)
 }
 
 export async function decryptAccountKeySecret(
@@ -46,9 +46,18 @@ export async function decryptAccountKeySecret(
 export async function decryptKeySecretUsingPin(
   key: Key | EncryptedKeySecret,
   pin: string
-) {
+): Promise<Secret> {
   if (typeof key.secret === 'object') {
     return key.secret
+  }
+
+  if (!key.secret) {
+    if ('accountId' in key && key.accountId) {
+      return decryptAccountKeySecretUsingPin(key.accountId, key.index, pin)
+    }
+    throw new Error(
+      'Key secret not available: no in-memory secret and no account context'
+    )
   }
 
   let decryptedSecret = ''


### PR DESCRIPTION
## Problem

Key secrets live in secure storage keyed by `accountId` + `keyIndex`, but keys
loaded from the database are hydrated with `secret: ''`. Calling
`decryptKeySecret(key)` on such a key attempts to AES-decrypt an empty string
and fails with "AES decryption failed".

The bug is latent: freshly created accounts keep the encrypted secret string on
the key object for the session, so key-based decryption works until the app is
restarted. After a reload it breaks — e.g. exporting seed words
(`seedWords.tsx`) and the `getKeyFingerprint` fallback for keys without a
stored fingerprint.

## Solution

Give `Key` an optional `accountId` back-reference so a key can locate its own
secret:

- Set `accountId` when mapping DB rows to accounts (`rowToAccount`).
- Strip it when serializing keys back to the DB (`keysToJson`), so nothing
  redundant is persisted. No storage migration needed.
- `decryptKeySecretUsingPin` now resolves the secret in order: already
  decrypted object → in-memory encrypted string (builder flow / same session)
  → secure storage via `accountId` → clear error when neither is available.

Also removed an unnecessary `as Key` cast in `decryptAccountKeySecretUsingPin`.