### PR TITLE
after adding duress pin, automatically enable it

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/settings/security.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/settings/security.tsx
@@ -44,15 +44,11 @@ export default function Security() {
   const [localPinMaxTries, setLocalPinMaxTries] = useState(pinMaxTries)
   const [localSkipSeedWordConfirmation, setLocalSkipSeedWordConfirmation] =
     useState(skipSeedConfirmation)
-  const [localDuressPinEnabled, setLocalDuressPinEnabled] =
-    useState(duressPinEnabled)
-
   const [duressPinModalVisible, setDuressPinModalVisible] = useState(false)
 
   function handleOnSave() {
     setPinMaxTries(localPinMaxTries)
     setSkipSeedConfirmation(localSkipSeedWordConfirmation)
-    setDuressPinEnabled(localDuressPinEnabled)
     router.back()
   }
 
@@ -100,8 +96,8 @@ export default function Security() {
               <SSText uppercase>{tn('duressPin')}</SSText>
               <SSCheckbox
                 label={tn('duressPinEnabled')}
-                selected={localDuressPinEnabled}
-                onPress={() => setLocalDuressPinEnabled(!localDuressPinEnabled)}
+                selected={duressPinEnabled}
+                onPress={() => setDuressPinEnabled(!duressPinEnabled)}
               />
               <SSButton
                 label={tn('duressPinSet')}

--- a/apps/mobile/app/setDuressPin.tsx
+++ b/apps/mobile/app/setDuressPin.tsx
@@ -8,14 +8,13 @@ import { SSIconCheckCircleThin, SSIconCircleXThin } from '@/components/icons'
 import SSButton from '@/components/SSButton'
 import SSPinInput from '@/components/SSPinInput'
 import SSText from '@/components/SSText'
-import { DURESS_PIN_KEY } from '@/config/auth'
 import SSMainLayout from '@/layouts/SSMainLayout'
 import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
 import { useAuthStore } from '@/store/auth'
 import { useSettingsStore } from '@/store/settings'
 import { Layout, Sizes } from '@/styles'
-import { checkPinEqual, emptyPin, setPin } from '@/utils/pin'
+import { checkPinEqual, emptyPin } from '@/utils/pin'
 
 type Stage = 'set' | 're-enter'
 
@@ -24,8 +23,12 @@ const BOTTOM_ACTIONS_MIN_HEIGHT = Sizes.button.height * 2 + Layout.vStack.gap.md
 export default function SetPin() {
   const router = useRouter()
   const insets = useSafeAreaInsets()
-  const [setFirstTime, setRequiresAuth] = useAuthStore(
-    useShallow((state) => [state.setFirstTime, state.setRequiresAuth])
+  const [setFirstTime, setRequiresAuth, setDuressPin] = useAuthStore(
+    useShallow((state) => [
+      state.setFirstTime,
+      state.setRequiresAuth,
+      state.setDuressPin
+    ])
   )
   const showWarning = useSettingsStore((state) => state.showWarning)
 
@@ -40,14 +43,14 @@ export default function SetPin() {
   const confirmationPinFilled = !confirmationPinArray.includes('')
   const pinsMatch = pinArray.join('') === confirmationPinArray.join('')
 
-  async function setDuressPin(pin: string) {
+  async function handleValidateAndSetDuressPin(pin: string) {
     const duressEqualCurrent = await checkPinEqual(pin)
     if (duressEqualCurrent) {
       toast.error(t('auth.pinMatchDuressPin'))
       handleGoBack()
       return false
     }
-    await setPin(pin, DURESS_PIN_KEY)
+    await setDuressPin(pin)
     return true
   }
 
@@ -77,7 +80,7 @@ export default function SetPin() {
     }
 
     setLoading(true)
-    const isPinSet = await setDuressPin(pinArray.join(''))
+    const isPinSet = await handleValidateAndSetDuressPin(pinArray.join(''))
     setLoading(false)
 
     if (!isPinSet) {

--- a/apps/mobile/store/auth.ts
+++ b/apps/mobile/store/auth.ts
@@ -103,6 +103,7 @@ const useAuthStore = create<AuthState & AuthAction>()(
       },
       setDuressPin: async (pin) => {
         await setPin(pin, DURESS_PIN_KEY)
+        set({ duressPinEnabled: true })
       },
       setDuressPinEnabled(duressPinEnabled) {
         set({ duressPinEnabled })


### PR DESCRIPTION
Fixes #475.  See it for details about the problem.

By default duress pin is disabled and unset.
After setting new duress pin, it is going to be automatically enabled.
The duress pin can be disabled or re-enabled manually any time (regardless if it is set or not).
Disabling duress pin does not erase it if it was set before. Re-enabling it would still work.

