### PR TITLE
feat: LND REST pairing, lightning flows, and ecash backup restore

### DIFF
--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ark/account/[id]/settings/board.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ark/account/[id]/settings/board.tsx
@@ -1,12 +1,12 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { ScrollView, StyleSheet, View } from 'react-native'
 import { toast } from 'sonner-native'
 import { useShallow } from 'zustand/react/shallow'
 
 import SSAmountInput from '@/components/SSAmountInput'
 import SSButton from '@/components/SSButton'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import { DUST_LIMIT } from '@/constants/btc'
 import {
@@ -53,6 +53,7 @@ export default function ArkBoardPage() {
   const { fundFromLinkedAccount, linkedAccount } = useArkBoardDeposit(account)
 
   const [amountSats, setAmountSats] = useState(0)
+  const qrRef = useRef<View>(null)
 
   const confirmedSats = balanceQuery.data?.confirmedSats ?? 0
   const pendingSats = balanceQuery.data?.pendingSats ?? 0
@@ -191,19 +192,23 @@ export default function ArkBoardPage() {
             )}
             {depositAddress && (
               <SSVStack gap="sm">
-                <View style={styles.qrContainer}>
-                  <SSQRCode value={depositAddress} size={DEPOSIT_QR_SIZE} />
-                </View>
-                <View style={styles.addressBox}>
-                  <SSText size="sm" style={styles.monospace}>
-                    {depositAddress}
-                  </SSText>
-                </View>
-                <SSButton
-                  label={t('common.copy')}
-                  onPress={handleCopyAddress}
-                  variant="outline"
-                />
+                <SSShareableQR
+                  qrRef={qrRef}
+                  value={depositAddress}
+                  size={DEPOSIT_QR_SIZE}
+                  containerStyle={styles.qrContainer}
+                >
+                  <View style={styles.addressBox}>
+                    <SSText size="sm" style={styles.monospace}>
+                      {depositAddress}
+                    </SSText>
+                  </View>
+                  <SSButton
+                    label={t('common.copy')}
+                    onPress={handleCopyAddress}
+                    variant="outline"
+                  />
+                </SSShareableQR>
                 {linkedAccount && (
                   <SSButton
                     label={t('ark.board.fundFromLinked', {

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ark/receive.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ark/receive.tsx
@@ -7,7 +7,7 @@ import { toast } from 'sonner-native'
 import SSAmountInput from '@/components/SSAmountInput'
 import SSButton from '@/components/SSButton'
 import SSPairedTabs from '@/components/SSPairedTabs'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import SSTextInput from '@/components/SSTextInput'
 import { DUST_LIMIT } from '@/constants/btc'
@@ -152,19 +152,22 @@ export default function ArkReceivePage() {
               )}
               {addressQuery.data && (
                 <>
-                  <View style={styles.qrContainer}>
-                    <SSQRCode value={addressQuery.data} size={280} />
-                  </View>
-                  <View style={styles.addressBox}>
-                    <SSText size="sm" style={styles.monospace}>
-                      {addressQuery.data}
-                    </SSText>
-                  </View>
-                  <SSButton
-                    label={t('common.copy')}
-                    onPress={handleCopyAddress}
-                    variant="outline"
-                  />
+                  <SSShareableQR
+                    value={addressQuery.data}
+                    size={280}
+                    containerStyle={styles.qrContainer}
+                  >
+                    <View style={styles.addressBox}>
+                      <SSText size="sm" style={styles.monospace}>
+                        {addressQuery.data}
+                      </SSText>
+                    </View>
+                    <SSButton
+                      label={t('common.copy')}
+                      onPress={handleCopyAddress}
+                      variant="outline"
+                    />
+                  </SSShareableQR>
                   <SSButton
                     label={t('ark.receive.generateNewAddress')}
                     onPress={handleGenerateNewAddress}
@@ -213,22 +216,25 @@ export default function ArkReceivePage() {
               )}
               {invoice && (
                 <>
-                  <View style={styles.qrContainer}>
-                    <SSQRCode value={invoice.invoice} size={280} />
-                  </View>
-                  <View style={styles.addressBox}>
-                    <SSText size="sm" style={styles.monospace}>
-                      {invoice.invoice}
+                  <SSShareableQR
+                    value={invoice.invoice}
+                    size={280}
+                    containerStyle={styles.qrContainer}
+                  >
+                    <View style={styles.addressBox}>
+                      <SSText size="sm" style={styles.monospace}>
+                        {invoice.invoice}
+                      </SSText>
+                    </View>
+                    <SSText color="muted" size="sm" center>
+                      {formatNumber(invoice.amountSats)} {t('bitcoin.sats')}
                     </SSText>
-                  </View>
-                  <SSText color="muted" size="sm" center>
-                    {formatNumber(invoice.amountSats)} {t('bitcoin.sats')}
-                  </SSText>
-                  <SSButton
-                    label={t('common.copy')}
-                    onPress={() => copyToClipboard(invoice.invoice)}
-                    variant="outline"
-                  />
+                    <SSButton
+                      label={t('common.copy')}
+                      onPress={() => copyToClipboard(invoice.invoice)}
+                      variant="outline"
+                    />
+                  </SSShareableQR>
                   <SSButton
                     label={t('ark.receive.newInvoice')}
                     onPress={handleResetInvoice}
@@ -259,19 +265,22 @@ export default function ArkReceivePage() {
               )}
               {onchainAddressQuery.data && (
                 <>
-                  <View style={styles.qrContainer}>
-                    <SSQRCode value={onchainAddressQuery.data} size={280} />
-                  </View>
-                  <View style={styles.addressBox}>
-                    <SSText size="sm" style={styles.monospace}>
-                      {onchainAddressQuery.data}
-                    </SSText>
-                  </View>
-                  <SSButton
-                    label={t('common.copy')}
-                    onPress={handleCopyOnchainAddress}
-                    variant="outline"
-                  />
+                  <SSShareableQR
+                    value={onchainAddressQuery.data}
+                    size={280}
+                    containerStyle={styles.qrContainer}
+                  >
+                    <View style={styles.addressBox}>
+                      <SSText size="sm" style={styles.monospace}>
+                        {onchainAddressQuery.data}
+                      </SSText>
+                    </View>
+                    <SSButton
+                      label={t('common.copy')}
+                      onPress={handleCopyOnchainAddress}
+                      variant="outline"
+                    />
+                  </SSShareableQR>
                 </>
               )}
               {autoBoard.minAmountSats !== undefined && (

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/receive.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/receive.tsx
@@ -2,7 +2,7 @@ import * as Clipboard from 'expo-clipboard'
 import * as Haptics from 'expo-haptics'
 import { Redirect, Stack, useLocalSearchParams, useRouter } from 'expo-router'
 import { useEffect, useRef, useState } from 'react'
-import { StyleSheet, TextInput } from 'react-native'
+import { StyleSheet, TextInput, View } from 'react-native'
 import { KeychainKind, Psbt } from 'react-native-bdk-sdk'
 import { toast } from 'sonner-native'
 import { useShallow } from 'zustand/react/shallow'
@@ -14,7 +14,8 @@ import SSEllipsisAnimation from '@/components/SSEllipsisAnimation'
 import SSLoader from '@/components/SSLoader'
 import SSNumberInput from '@/components/SSNumberInput'
 import SSPsbtTransport from '@/components/SSPsbtTransport'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSSuccessCheckAnimation from '@/components/SSSuccessCheckAnimation'
 import SSText from '@/components/SSText'
 import SSTextInput from '@/components/SSTextInput'
@@ -161,6 +162,7 @@ export default function Receive() {
   // Distinguishes "user turned Payjoin off" from "we auto-disabled while UTXOs
   // were still empty on first paint" so we can re-enable once coins appear.
   const userSetPayjoinRef = useRef(false)
+  const qrRef = useRef<View>(null)
 
   // Master switch is read-only here; per-invoice control is local `includePayjoin`.
   const payjoinEnabled = useSettingsStore((state) => state.payjoinEnabled)
@@ -656,7 +658,8 @@ export default function Receive() {
             ) : (
               localFinalAddressQR && (
                 <SSVStack itemsCenter gap="md">
-                  <SSQRCode
+                  <SSShareableQR
+                    qrRef={qrRef}
                     // BIP77 pj= URIs are long — H ecl overflows and yields no QR.
                     ecl={
                       localFinalAddressQR.toLowerCase().includes('pj=')
@@ -664,6 +667,7 @@ export default function Receive() {
                         : 'H'
                     }
                     value={localFinalAddressQR}
+                    hideShareButton
                   />
                   <SSHStack>
                     {nfcHardwareSupported && (
@@ -701,6 +705,7 @@ export default function Receive() {
                   style={styles.copyButton}
                   onPress={() => copyToClipboard(localFinalAddressQR)}
                 />
+                <SSShareButton qrRef={qrRef} />
                 <SSHStack gap="sm" style={styles.uriActionsRow}>
                   <SSButton
                     label={

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/descriptor.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/descriptor.tsx
@@ -1,12 +1,13 @@
 import { Redirect, router, Stack, useLocalSearchParams } from 'expo-router'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { ScrollView, View } from 'react-native'
 import { walletNameFromDescriptor } from 'react-native-bdk-sdk'
 import { toast } from 'sonner-native'
 
 import SSButton from '@/components/SSButton'
 import SSClipboardCopy from '@/components/SSClipboardCopy'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSText from '@/components/SSText'
 import { useAsyncEffect } from '@/hooks/useAsyncEffect'
 import SSVStack from '@/layouts/SSVStack'
@@ -32,6 +33,7 @@ export default function DescriptorPage() {
 
   const [descriptor, setDescriptor] = useState('')
   const [isLoading, setIsLoading] = useState(true)
+  const qrRef = useRef<View>(null)
   const [keyName, setKeyName] = useState('')
   const [creationType, setCreationType] = useState('')
   const [scriptVersion, setScriptVersion] = useState<string>('P2PKH')
@@ -197,20 +199,19 @@ export default function DescriptorPage() {
               </SSText>
             </View>
           ) : descriptor ? (
-            <View
-              style={{
+            <SSShareableQR
+              qrRef={qrRef}
+              value={descriptor}
+              size={250}
+              color="black"
+              backgroundColor="white"
+              containerStyle={{
                 backgroundColor: 'white',
                 borderRadius: 10,
                 padding: 20
               }}
-            >
-              <SSQRCode
-                value={descriptor}
-                size={250}
-                color="black"
-                backgroundColor="white"
-              />
-            </View>
+              hideShareButton
+            />
           ) : null}
         </View>
 
@@ -241,6 +242,7 @@ export default function DescriptorPage() {
               variant="secondary"
               onPress={exportDescriptor}
             />
+            <SSShareButton qrRef={qrRef} />
           </>
         )}
 

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/descriptors.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/descriptors.tsx
@@ -9,8 +9,9 @@ import { getExtendedPublicKeyFromAccountKey } from '@/api/bdk'
 import { SSIconEyeOn } from '@/components/icons'
 import SSButton from '@/components/SSButton'
 import SSClipboardCopy from '@/components/SSClipboardCopy'
-import SSQRCode from '@/components/SSQRCode'
 import SSRadioButton from '@/components/SSRadioButton'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSText from '@/components/SSText'
 import SSHStack from '@/layouts/SSHStack'
 import SSVStack from '@/layouts/SSVStack'
@@ -66,6 +67,37 @@ function calculateDescriptorChecksum(descriptor: string): string {
   } catch {
     return ''
   }
+}
+
+type DescriptorQrItemProps = {
+  descriptor: string
+  label: string
+}
+
+function DescriptorQrItem({ descriptor, label }: DescriptorQrItemProps) {
+  return (
+    <View style={{ alignItems: 'center' }}>
+      <SSShareableQR
+        value={descriptor}
+        size={150}
+        color={Colors.black}
+        backgroundColor={Colors.white}
+        containerStyle={{
+          backgroundColor: Colors.white,
+          borderRadius: 2,
+          padding: 16
+        }}
+      >
+        <SSText
+          color="muted"
+          size="sm"
+          style={{ marginBottom: 8, marginTop: 8 }}
+        >
+          {label}
+        </SSText>
+      </SSShareableQR>
+    </View>
+  )
 }
 
 export default function ExportDescriptors() {
@@ -723,45 +755,28 @@ export default function ExportDescriptors() {
             {showSeparate ? (
               <SSVStack gap="md">
                 {descriptors.map((descriptor, index) => (
-                  <View key={descriptor} style={{ alignItems: 'center' }}>
-                    <View
-                      style={{
-                        backgroundColor: Colors.white,
-                        borderRadius: 2,
-                        padding: 16
-                      }}
-                    >
-                      <SSQRCode
-                        value={descriptor}
-                        size={150}
-                        color={Colors.black}
-                        backgroundColor={Colors.white}
-                      />
-                    </View>
-                    <SSText color="muted" size="sm" style={{ marginTop: 8 }}>
-                      {index === 0 ? 'External' : 'Internal'}{' '}
-                      {t('common.descriptor')}
-                    </SSText>
-                  </View>
+                  <DescriptorQrItem
+                    key={descriptor}
+                    descriptor={descriptor}
+                    label={`${index === 0 ? 'External' : 'Internal'} ${t('common.descriptor')}`}
+                  />
                 ))}
               </SSVStack>
             ) : (
               <View style={{ alignItems: 'center' }}>
-                <View
-                  ref={qrRef}
-                  style={{
+                <SSShareableQR
+                  qrRef={qrRef}
+                  value={exportContent}
+                  size={250}
+                  color={Colors.black}
+                  backgroundColor={Colors.white}
+                  containerStyle={{
                     backgroundColor: Colors.white,
                     borderRadius: 2,
                     padding: 16
                   }}
-                >
-                  <SSQRCode
-                    value={exportContent}
-                    size={250}
-                    color={Colors.black}
-                    backgroundColor={Colors.white}
-                  />
-                </View>
+                  hideShareButton
+                />
               </View>
             )}
             <View
@@ -791,6 +806,7 @@ export default function ExportDescriptors() {
               variant="outline"
               onPress={exportDescriptors}
             />
+            {!showSeparate && <SSShareButton qrRef={qrRef} />}
           </>
         ) : (
           <SSText center color="muted">

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/pubkeys.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/pubkeys.tsx
@@ -1,5 +1,5 @@
 import { Redirect, router, Stack, useLocalSearchParams } from 'expo-router'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ActivityIndicator, ScrollView, StyleSheet, View } from 'react-native'
 import { toast } from 'sonner-native'
 
@@ -7,7 +7,8 @@ import { getWalletData } from '@/api/bdk'
 import { SSIconEyeOn } from '@/components/icons'
 import SSButton from '@/components/SSButton'
 import SSClipboardCopy from '@/components/SSClipboardCopy'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSText from '@/components/SSText'
 import SSHStack from '@/layouts/SSHStack'
 import SSVStack from '@/layouts/SSVStack'
@@ -32,6 +33,7 @@ export default function ExportPubkeys() {
 
   const [exportContent, setExportContent] = useState('')
   const [isLoading, setIsLoading] = useState(true)
+  const qrRef = useRef<View>(null)
   const [pubkeyFormat, setPubkeyFormat] = useState<'xpub' | 'zpub' | 'vpub'>(
     'xpub'
   )
@@ -162,20 +164,19 @@ export default function ExportPubkeys() {
           {isLoading ? (
             <ActivityIndicator size="large" color={Colors.gray[400]} />
           ) : exportContent ? (
-            <View
-              style={{
+            <SSShareableQR
+              qrRef={qrRef}
+              value={exportContent}
+              size={250}
+              color="black"
+              backgroundColor="white"
+              containerStyle={{
                 backgroundColor: 'white',
                 borderRadius: 10,
                 padding: 20
               }}
-            >
-              <SSQRCode
-                value={exportContent}
-                size={250}
-                color="black"
-                backgroundColor="white"
-              />
-            </View>
+              hideShareButton
+            />
           ) : null}
         </View>
         {!isLoading && exportContent && (
@@ -202,6 +203,7 @@ export default function ExportPubkeys() {
               variant="secondary"
               onPress={exportPubkeys}
             />
+            <SSShareButton qrRef={qrRef} />
           </>
         )}
         <SSButton

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/publicKey.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/export/publicKey.tsx
@@ -1,11 +1,12 @@
 import { Redirect, router, Stack, useLocalSearchParams } from 'expo-router'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { ScrollView, View } from 'react-native'
 import { toast } from 'sonner-native'
 
 import SSButton from '@/components/SSButton'
 import SSClipboardCopy from '@/components/SSClipboardCopy'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSText from '@/components/SSText'
 import { useAsyncEffect } from '@/hooks/useAsyncEffect'
 import SSHStack from '@/layouts/SSHStack'
@@ -36,6 +37,7 @@ export default function PublicKeyPage() {
 
   const [publicKey, setPublicKey] = useState('')
   const [isLoading, setIsLoading] = useState(true)
+  const qrRef = useRef<View>(null)
   const [rawPublicKey, setRawPublicKey] = useState('')
 
   // Derive scriptVersion and selectedFormat from account data and network
@@ -302,20 +304,19 @@ export default function PublicKeyPage() {
               </SSText>
             </View>
           ) : publicKey ? (
-            <View
-              style={{
+            <SSShareableQR
+              qrRef={qrRef}
+              value={publicKey}
+              size={250}
+              color="black"
+              backgroundColor="white"
+              containerStyle={{
                 backgroundColor: 'white',
                 borderRadius: 10,
                 padding: 20
               }}
-            >
-              <SSQRCode
-                value={publicKey}
-                size={250}
-                color="black"
-                backgroundColor="white"
-              />
-            </View>
+              hideShareButton
+            />
           ) : null}
         </View>
 
@@ -346,6 +347,7 @@ export default function PublicKeyPage() {
               variant="secondary"
               onPress={exportPublicKey}
             />
+            <SSShareButton qrRef={qrRef} />
           </>
         )}
 

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/nostr/nostrKey.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/settings/nostr/nostrKey.tsx
@@ -17,8 +17,8 @@ import SSIconEyeOn from '@/components/icons/SSIconEyeOn'
 import SSButton from '@/components/SSButton'
 import SSTextClipboard from '@/components/SSClipboardCopy'
 import SSModal from '@/components/SSModal'
-import SSQRCode from '@/components/SSQRCode'
 import SSSeedQR from '@/components/SSSeedQR'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import SSTextInput from '@/components/SSTextInput'
 import { NOSTR_FALLBACK_NPUB_COLOR } from '@/constants/nostr'
@@ -750,25 +750,26 @@ function NostrKeys() {
                   ? t('account.nostrSync.npub')
                   : t('account.nostrSync.nsec')}
               </SSText>
-              <View style={styles.qrCodeWrapper}>
-                <SSQRCode
-                  value={qrModal.value}
-                  size={220}
-                  color={Colors.white}
-                  backgroundColor={Colors.gray[950]}
-                  ecl="H"
-                />
-              </View>
-              <View style={styles.qrModalDataBox}>
-                <SSText
-                  type="mono"
-                  size="sm"
-                  selectable
-                  style={styles.qrModalDataText}
-                >
-                  {qrModal.value}
-                </SSText>
-              </View>
+              <SSShareableQR
+                value={qrModal.value}
+                size={220}
+                color={Colors.white}
+                backgroundColor={Colors.gray[950]}
+                ecl="H"
+                containerStyle={styles.qrCodeWrapper}
+                hideShareButton={qrModal.type !== 'npub'}
+              >
+                <View style={styles.qrModalDataBox}>
+                  <SSText
+                    type="mono"
+                    size="sm"
+                    selectable
+                    style={styles.qrModalDataText}
+                  >
+                    {qrModal.value}
+                  </SSText>
+                </View>
+              </SSShareableQR>
             </>
           )}
         </SSVStack>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/previewTransaction.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/signAndSend/previewTransaction.tsx
@@ -27,8 +27,8 @@ import SSButton from '@/components/SSButton'
 import SSDustWarningBanner from '@/components/SSDustWarningBanner'
 import SSKeyboardWordSelector from '@/components/SSKeyboardWordSelector'
 import SSModal from '@/components/SSModal'
-import SSQRCode from '@/components/SSQRCode'
 import SSSeedWordsInput from '@/components/SSSeedWordsInput'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSSignatureDropdown from '@/components/SSSignatureDropdown'
 import SSSignatureRequiredDisplay from '@/components/SSSignatureRequiredDisplay'
 import SSText from '@/components/SSText'
@@ -683,6 +683,7 @@ function PreviewTransaction() {
 
   // Animation refs to prevent unnecessary re-renders
   const animationRef = useRef<number | null>(null)
+  const qrRef = useRef<View>(null)
   const lastUpdateRef = useRef<number>(0)
 
   // Multi-part QR scanning state
@@ -1365,25 +1366,28 @@ function PreviewTransaction() {
     }
   }, [getPsbtString, txBuilderResult, qrComplexity, createRawPsbtChunks])
 
+  // Whether the current display mode is cycling through more than one chunk
+  function isMultiPartQR() {
+    switch (displayMode) {
+      case QRDisplayMode.RAW:
+        return rawPsbtChunks.length > 1
+      case QRDisplayMode.UR:
+        return urChunks.length > 1
+      case QRDisplayMode.BBQR:
+        return qrChunks.length > 1
+      default:
+        return false
+    }
+  }
+
   // High-performance animation using requestAnimationFrame
   useEffect(() => {
     // Don't animate when complexity is 12 (static mode) - but only for single chunks
-    if (qrComplexity === 12) {
-      // Check if we actually have a single chunk or multiple chunks
-      const hasMultipleChunks =
-        (displayMode === QRDisplayMode.RAW && rawPsbtChunks.length > 1) ||
-        (displayMode === QRDisplayMode.BBQR && qrChunks.length > 1) ||
-        (displayMode === QRDisplayMode.UR && urChunks.length > 1)
-
-      if (!hasMultipleChunks) {
-        return // Don't animate if we have a single chunk
-      }
+    if (qrComplexity === 12 && !isMultiPartQR()) {
+      return // Don't animate if we have a single chunk
     }
 
-    const shouldAnimate =
-      (displayMode === QRDisplayMode.RAW && rawPsbtChunks.length > 1) ||
-      (displayMode === QRDisplayMode.BBQR && qrChunks.length > 1) ||
-      (displayMode === QRDisplayMode.UR && urChunks.length > 1)
+    const shouldAnimate = isMultiPartQR()
 
     if (shouldAnimate) {
       // Calculate animation interval based on speed (1 = slowest, 12 = fastest)
@@ -1420,6 +1424,7 @@ function PreviewTransaction() {
         }
       }
     }
+    // oxlint-disable-next-line eslint-plugin-react-hooks/exhaustive-deps
   }, [
     displayMode,
     qrChunks.length,
@@ -2559,24 +2564,22 @@ function PreviewTransaction() {
                 {qrError}
               </SSText>
             ) : qrChunks.length > 0 ? (
-              <>
-                <View
-                  style={{
-                    alignItems: 'center',
-                    backgroundColor: Colors.white,
-                    borderRadius: 2,
-                    marginBottom: 0,
-                    padding: 5,
-                    width: qrSize + 10
-                  }}
-                >
-                  <SSQRCode
-                    value={getQRValue()}
-                    color={Colors.black}
-                    backgroundColor={Colors.white}
-                    size={qrSize}
-                  />
-                </View>
+              <SSShareableQR
+                qrRef={qrRef}
+                value={getQRValue()}
+                color={Colors.black}
+                backgroundColor={Colors.white}
+                size={qrSize}
+                hideShareButton={isMultiPartQR()}
+                containerStyle={{
+                  alignItems: 'center',
+                  backgroundColor: Colors.white,
+                  borderRadius: 2,
+                  marginBottom: 0,
+                  padding: 5,
+                  width: qrSize + 10
+                }}
+              >
                 <View
                   style={[
                     styles.qrFormatSegmentTrack,
@@ -2645,71 +2648,73 @@ function PreviewTransaction() {
                     ? `${getQRValue().slice(0, 100)}...`
                     : getQRValue()}
                 </SSText>
-                <SSHStack
-                  justifyEvenly
-                  style={{ marginBottom: 20, width: screenWidth * 0.9 }}
-                >
-                  <SSVStack gap="xs">
-                    <SSText color="white" size="sm" center>
-                      QR density: {qrComplexity}/12
-                    </SSText>
-                    <SSHStack gap="sm" style={{ justifyContent: 'center' }}>
-                      <SSButton
-                        variant="outline"
-                        label="-"
-                        onPress={() =>
-                          setQrComplexity(Math.max(1, qrComplexity - 1))
+              </SSShareableQR>
+            ) : null}
+            {qrChunks.length > 0 ? (
+              <SSHStack
+                justifyEvenly
+                style={{ marginBottom: 20, width: screenWidth * 0.9 }}
+              >
+                <SSVStack gap="xs">
+                  <SSText color="white" size="sm" center>
+                    QR density: {qrComplexity}/12
+                  </SSText>
+                  <SSHStack gap="sm" style={{ justifyContent: 'center' }}>
+                    <SSButton
+                      variant="outline"
+                      label="-"
+                      onPress={() =>
+                        setQrComplexity(Math.max(1, qrComplexity - 1))
+                      }
+                      style={{ height: 50, width: 50 }}
+                    />
+                    <SSButton
+                      variant={
+                        qrComplexity === 11 && isDataTooLargeForSingleQR()
+                          ? 'ghost'
+                          : 'outline'
+                      }
+                      label="+"
+                      onPress={() => {
+                        const newComplexity = qrComplexity + 1
+                        // Check if the new complexity would create data too large for QR codes
+                        if (
+                          newComplexity === 12 &&
+                          isDataTooLargeForSingleQR()
+                        ) {
+                          toast.error(t('common.error.dataTooLarge'))
+                          return
                         }
-                        style={{ height: 50, width: 50 }}
-                      />
-                      <SSButton
-                        variant={
-                          qrComplexity === 11 && isDataTooLargeForSingleQR()
-                            ? 'ghost'
-                            : 'outline'
-                        }
-                        label="+"
-                        onPress={() => {
-                          const newComplexity = qrComplexity + 1
-                          // Check if the new complexity would create data too large for QR codes
-                          if (
-                            newComplexity === 12 &&
-                            isDataTooLargeForSingleQR()
-                          ) {
-                            toast.error(t('common.error.dataTooLarge'))
-                            return
-                          }
-                          setQrComplexity(Math.min(12, newComplexity))
-                        }}
-                        style={{ height: 50, width: 50 }}
-                      />
-                    </SSHStack>
-                  </SSVStack>
-                  <SSVStack gap="xs">
-                    <SSText color="white" size="sm" center>
-                      {t('common.speed')}: {animationSpeed}/12
-                    </SSText>
-                    <SSHStack gap="sm" style={{ justifyContent: 'center' }}>
-                      <SSButton
-                        variant="outline"
-                        label="-"
-                        onPress={() =>
-                          setAnimationSpeed(Math.max(1, animationSpeed - 1))
-                        }
-                        style={{ height: 50, width: 50 }}
-                      />
-                      <SSButton
-                        variant="outline"
-                        label="+"
-                        onPress={() =>
-                          setAnimationSpeed(Math.min(12, animationSpeed + 1))
-                        }
-                        style={{ height: 50, width: 50 }}
-                      />
-                    </SSHStack>
-                  </SSVStack>
-                </SSHStack>
-              </>
+                        setQrComplexity(Math.min(12, newComplexity))
+                      }}
+                      style={{ height: 50, width: 50 }}
+                    />
+                  </SSHStack>
+                </SSVStack>
+                <SSVStack gap="xs">
+                  <SSText color="white" size="sm" center>
+                    {t('common.speed')}: {animationSpeed}/12
+                  </SSText>
+                  <SSHStack gap="sm" style={{ justifyContent: 'center' }}>
+                    <SSButton
+                      variant="outline"
+                      label="-"
+                      onPress={() =>
+                        setAnimationSpeed(Math.max(1, animationSpeed - 1))
+                      }
+                      style={{ height: 50, width: 50 }}
+                    />
+                    <SSButton
+                      variant="outline"
+                      label="+"
+                      onPress={() =>
+                        setAnimationSpeed(Math.min(12, animationSpeed + 1))
+                      }
+                      style={{ height: 50, width: 50 }}
+                    />
+                  </SSHStack>
+                </SSVStack>
+              </SSHStack>
             ) : (
               <SSText color="white" size="sm" style={{ marginTop: 16 }}>
                 {t('common.loading')}

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/transaction/[txid]/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/[id]/transaction/[txid]/index.tsx
@@ -139,6 +139,8 @@ export default function TxDetails() {
   const [weight, setWeight] = useState(placeholder)
 
   useEffect(() => {
+    // requestIdleCallback replaces deprecated InteractionManager.runAfterInteractions.
+    // Frame-tick driven: pauses while backgrounded; does not wait for UI-thread animations.
     const idleHandle = requestIdleCallback(() => {
       setIsReady(true)
     })

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/multiSig/export/descriptor.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/multiSig/export/descriptor.tsx
@@ -1,5 +1,5 @@
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ScrollView, View } from 'react-native'
 import { KeychainKind, walletNameFromDescriptor } from 'react-native-bdk-sdk'
 import { toast } from 'sonner-native'
@@ -7,7 +7,8 @@ import { useShallow } from 'zustand/react/shallow'
 
 import SSButton from '@/components/SSButton'
 import SSClipboardCopy from '@/components/SSClipboardCopy'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSText from '@/components/SSText'
 import SSVStack from '@/layouts/SSVStack'
 import { t } from '@/locales'
@@ -34,6 +35,7 @@ export default function DescriptorPage() {
 
   const [isLoading, setIsLoading] = useState(true)
   const [descriptor, setDescriptor] = useState('')
+  const qrRef = useRef<View>(null)
   const [keyName, setKeyName] = useState('')
   const [creationType, setCreationType] = useState<CreationType | null>()
   const [scriptVersion, setScriptVersion] =
@@ -204,20 +206,19 @@ export default function DescriptorPage() {
               </SSText>
             </View>
           ) : descriptor ? (
-            <View
-              style={{
+            <SSShareableQR
+              qrRef={qrRef}
+              value={descriptor}
+              size={250}
+              color="black"
+              backgroundColor="white"
+              containerStyle={{
                 backgroundColor: 'white',
                 borderRadius: 10,
                 padding: 20
               }}
-            >
-              <SSQRCode
-                value={descriptor}
-                size={250}
-                color="black"
-                backgroundColor="white"
-              />
-            </View>
+              hideShareButton
+            />
           ) : null}
         </View>
 
@@ -248,6 +249,7 @@ export default function DescriptorPage() {
               variant="secondary"
               onPress={exportDescriptor}
             />
+            <SSShareButton qrRef={qrRef} />
           </>
         )}
 

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/multiSig/export/publicKey.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/bitcoin/account/add/multiSig/export/publicKey.tsx
@@ -1,12 +1,13 @@
 import { useLocalSearchParams, useRouter } from 'expo-router'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ScrollView, View } from 'react-native'
 import { toast } from 'sonner-native'
 import { useShallow } from 'zustand/react/shallow'
 
 import SSButton from '@/components/SSButton'
 import SSClipboardCopy from '@/components/SSClipboardCopy'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSText from '@/components/SSText'
 import { useAsyncEffect } from '@/hooks/useAsyncEffect'
 import SSHStack from '@/layouts/SSHStack'
@@ -32,6 +33,7 @@ export default function PublicKeyPage() {
 
   const [publicKey, setPublicKey] = useState('')
   const [isLoading, setIsLoading] = useState(true)
+  const qrRef = useRef<View>(null)
   const [selectedFormat, setSelectedFormat] = useState<PublicKeyFormat>('xpub')
   const [rawPublicKey, setRawPublicKey] = useState('')
   const [scriptVersion, setScriptVersion] = useState('P2WPKH')
@@ -291,20 +293,19 @@ export default function PublicKeyPage() {
               </SSText>
             </View>
           ) : publicKey ? (
-            <View
-              style={{
+            <SSShareableQR
+              qrRef={qrRef}
+              value={publicKey}
+              size={250}
+              color="black"
+              backgroundColor="white"
+              containerStyle={{
                 backgroundColor: 'white',
                 borderRadius: 10,
                 padding: 20
               }}
-            >
-              <SSQRCode
-                value={publicKey}
-                size={250}
-                color="black"
-                backgroundColor="white"
-              />
-            </View>
+              hideShareButton
+            />
           ) : null}
         </View>
         {/* Public Key Text */}
@@ -334,6 +335,7 @@ export default function PublicKeyPage() {
               variant="secondary"
               onPress={exportPublicKey}
             />
+            <SSShareButton qrRef={qrRef} />
           </>
         )}
         <SSButton

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ecash/account/[id]/proof/[proofIndex]/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ecash/account/[id]/proof/[proofIndex]/index.tsx
@@ -1,14 +1,15 @@
 import * as Clipboard from 'expo-clipboard'
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router'
 import { useEffect, useRef, useState } from 'react'
-import { Pressable, StyleSheet, useWindowDimensions } from 'react-native'
+import { Pressable, StyleSheet, useWindowDimensions, View } from 'react-native'
 import { toast } from 'sonner-native'
 import { useShallow } from 'zustand/react/shallow'
 
 import { encodeProofsAsToken } from '@/api/ecash'
 import SSButton from '@/components/SSButton'
 import SSNFCModal from '@/components/SSNFCModal'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSStyledSatText from '@/components/SSStyledSatText'
 import SSText from '@/components/SSText'
 import SSTextInput from '@/components/SSTextInput'
@@ -61,6 +62,7 @@ export default function EcashProofDetailPage() {
   const [currentChunkIndex, setCurrentChunkIndex] = useState(0)
   const [nfcModalVisible, setNfcModalVisible] = useState(false)
   const animationRef = useRef<number | null>(null)
+  const qrRef = useRef<View>(null)
   const lastUpdateRef = useRef(0)
 
   const [currencyUnit, privacyMode, useZeroPadding] = useSettingsStore(
@@ -452,10 +454,12 @@ export default function EcashProofDetailPage() {
                   </Pressable>
                 </SSHStack>
                 <SSVStack gap="xs" itemsCenter>
-                  <SSQRCode
+                  <SSShareableQR
+                    qrRef={qrRef}
                     value={getQRValue()}
                     size={qrSize}
                     ecl={animatedQR && isMultiPart ? 'L' : 'H'}
+                    hideShareButton
                   />
                   <SSText color="muted" size="xs" style={styles.chunkCounter}>
                     {animatedQR && isMultiPart
@@ -529,6 +533,9 @@ export default function EcashProofDetailPage() {
                     style={{ flex: 1 }}
                   />
                 </SSHStack>
+                {!(animatedQR && isMultiPart) && (
+                  <SSShareButton qrRef={qrRef} />
+                )}
               </SSVStack>
             )}
           </SSVStack>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ecash/receive.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ecash/receive.tsx
@@ -10,7 +10,7 @@ import SSCameraModal from '@/components/SSCameraModal'
 import SSEcashLightningTabs from '@/components/SSEcashLightningTabs'
 import SSEcashMintSelector from '@/components/SSEcashMintSelector'
 import SSEcashTokenDetails from '@/components/SSEcashTokenDetails'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import SSTextInput from '@/components/SSTextInput'
 import { useEcashReceive } from '@/hooks/useEcashReceive'
@@ -488,23 +488,24 @@ export default function EcashReceivePage() {
               ) : (
                 <SSVStack gap="md">
                   {!isLNURLWithdrawMode && (
-                    <View style={styles.qrContainer}>
-                      <SSQRCode value={mintQuote.request} size={300} />
-                    </View>
-                  )}
-                  {!isLNURLWithdrawMode && (
-                    <SSButton
-                      label={t('common.copy')}
-                      onPress={async () => {
-                        try {
-                          await Clipboard.setStringAsync(mintQuote.request)
-                          toast.success(t('common.copiedToClipboard'))
-                        } catch {
-                          toast.error(t('ecash.error.failedToCopy'))
-                        }
-                      }}
-                      variant="outline"
-                    />
+                    <SSShareableQR
+                      value={mintQuote.request}
+                      size={300}
+                      containerStyle={styles.qrContainer}
+                    >
+                      <SSButton
+                        label={t('common.copy')}
+                        onPress={async () => {
+                          try {
+                            await Clipboard.setStringAsync(mintQuote.request)
+                            toast.success(t('common.copiedToClipboard'))
+                          } catch {
+                            toast.error(t('ecash.error.failedToCopy'))
+                          }
+                        }}
+                        variant="outline"
+                      />
+                    </SSShareableQR>
                   )}
                   <SSVStack gap="none">
                     <SSText style={{ color: getStatusColor(quoteStatus) }}>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ecash/send.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ecash/send.tsx
@@ -1,7 +1,7 @@
 import * as Clipboard from 'expo-clipboard'
 import { Stack, useLocalSearchParams } from 'expo-router'
-import { useEffect, useState } from 'react'
-import { Pressable, StyleSheet, useWindowDimensions } from 'react-native'
+import { useEffect, useRef, useState } from 'react'
+import { Pressable, StyleSheet, useWindowDimensions, View } from 'react-native'
 import { toast } from 'sonner-native'
 import { useShallow } from 'zustand/react/shallow'
 
@@ -12,7 +12,8 @@ import SSEcashLightningTabs from '@/components/SSEcashLightningTabs'
 import SSEcashMintSelector from '@/components/SSEcashMintSelector'
 import SSLNURLDetails from '@/components/SSLNURLDetails'
 import SSPaymentDetails from '@/components/SSPaymentDetails'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
+import SSShareButton from '@/components/SSShareButton'
 import SSText from '@/components/SSText'
 import SSTextInput from '@/components/SSTextInput'
 import { ANIMATED_QR_INTERVAL_MS, useEcashSend } from '@/hooks/useEcashSend'
@@ -49,6 +50,7 @@ export default function EcashSendPage() {
   const { invoice: invoiceParam } = useLocalSearchParams()
   const [activeTab, setActiveTab] = useState<'ecash' | 'lightning'>('ecash')
   const [cameraModalVisible, setCameraModalVisible] = useState(false)
+  const qrRef = useRef<View>(null)
 
   const {
     activeAccount,
@@ -301,10 +303,12 @@ export default function EcashSendPage() {
                     </Pressable>
                   </SSHStack>
                   <SSVStack gap="xs" itemsCenter>
-                    <SSQRCode
+                    <SSShareableQR
+                      qrRef={qrRef}
                       value={getQRValue(chunks)}
                       size={qrSize}
                       ecl={animatedQR && isMultiPart ? 'M' : 'H'}
+                      hideShareButton
                     />
                     <SSText color="muted" size="xs" style={styles.chunkCounter}>
                       {animatedQR && isMultiPart
@@ -381,6 +385,9 @@ export default function EcashSendPage() {
                       style={{ flex: 1 }}
                     />
                   </SSHStack>
+                  {!(animatedQR && isMultiPart) && (
+                    <SSShareButton qrRef={qrRef} />
+                  )}
                 </SSVStack>
               )}
             </SSVStack>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ecash/transaction/[id]/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/ecash/transaction/[id]/index.tsx
@@ -13,7 +13,7 @@ import {
 } from '@/components/icons'
 import SSButton from '@/components/SSButton'
 import SSModal from '@/components/SSModal'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSStyledSatText from '@/components/SSStyledSatText'
 import SSText from '@/components/SSText'
 import SSTextInput from '@/components/SSTextInput'
@@ -583,7 +583,11 @@ export default function EcashTransactionDetailPage() {
           <SSText size="lg" weight="medium" style={{ textAlign: 'center' }}>
             {t('ecash.transactionDetail.lightningInvoice')}
           </SSText>
-          {lightningInvoice && <SSQRCode value={lightningInvoice} size={250} />}
+          {lightningInvoice && (
+            <>
+              <SSShareableQR value={lightningInvoice} size={250} />
+            </>
+          )}
         </SSVStack>
       </SSModal>
     </SSMainLayout>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/lightning/invoice.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/lightning/invoice.tsx
@@ -18,6 +18,7 @@ import SSCameraModal from '@/components/SSCameraModal'
 import SSModal from '@/components/SSModal'
 import SSPairedTabs from '@/components/SSPairedTabs'
 import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import { LND_INVOICE_POLL_MS } from '@/constants/lightning'
 import { useFiatData } from '@/hooks/useFiatData'
@@ -644,30 +645,33 @@ export default function InvoicePage() {
                 </View>
               </View>
             </SSVStack>
-            <View style={styles.qrContainer}>
-              {paymentRequest && (
-                <SSQRCode value={paymentRequest} size={qrCodeSize} />
-              )}
-            </View>
-            <SSVStack style={styles.paymentRequestContainer}>
-              <SSText color="muted" uppercase>
-                {t('lightning.invoice.paymentRequest')}
-              </SSText>
-              <View style={styles.paymentRequestText}>
-                <SSText type="mono" size="sm">
-                  {paymentRequest}
-                </SSText>
-              </View>
-            </SSVStack>
+            {paymentRequest ? (
+              <SSShareableQR
+                value={paymentRequest}
+                size={qrCodeSize}
+                containerStyle={styles.qrContainer}
+              >
+                <SSVStack style={styles.paymentRequestContainer}>
+                  <SSText color="muted" uppercase>
+                    {t('lightning.invoice.paymentRequest')}
+                  </SSText>
+                  <View style={styles.paymentRequestText}>
+                    <SSText type="mono" size="sm">
+                      {paymentRequest}
+                    </SSText>
+                  </View>
+                </SSVStack>
 
-            <SSVStack style={styles.modalActions}>
-              <SSButton
-                label={t('common.copyToClipboard')}
-                onPress={handleCopyToClipboard}
-                variant="gradient"
-                gradientType="special"
-              />
-            </SSVStack>
+                <SSVStack style={styles.modalActions}>
+                  <SSButton
+                    label={t('common.copyToClipboard')}
+                    onPress={handleCopyToClipboard}
+                    variant="gradient"
+                    gradientType="special"
+                  />
+                </SSVStack>
+              </SSShareableQR>
+            ) : null}
           </SSVStack>
         </ScrollView>
       </SSModal>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/nostr/account/[npub]/compose.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/nostr/account/[npub]/compose.tsx
@@ -16,7 +16,7 @@ import { NostrAPI } from '@/api/nostr'
 import SSButton from '@/components/SSButton'
 import SSCameraModal from '@/components/SSCameraModal'
 import SSModal from '@/components/SSModal'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import {
   NOSTR_NIP01_MAX_NOTE_LENGTH,
@@ -651,7 +651,7 @@ export default function NostrComposePage() {
           </SSText>
           {signedQrPayload ? (
             <View style={styles.signedQrWrap}>
-              <SSQRCode
+              <SSShareableQR
                 value={signedQrPayload}
                 size={220}
                 color={Colors.white}

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/nostr/account/[npub]/keys.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/nostr/account/[npub]/keys.tsx
@@ -15,8 +15,8 @@ import { toast } from 'sonner-native'
 import SSIconEyeOff from '@/components/icons/SSIconEyeOff'
 import SSButton from '@/components/SSButton'
 import SSModal from '@/components/SSModal'
-import SSQRCode from '@/components/SSQRCode'
 import SSSeedQR from '@/components/SSSeedQR'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import { NOSTR_HIDDEN_KEY_MASK } from '@/constants/nostr'
 import SSHStack from '@/layouts/SSHStack'
@@ -391,23 +391,24 @@ export default function NostrIdentityKeys() {
                   ? t('nostrIdentity.keys.npub')
                   : t('nostrIdentity.keys.nsec')}
               </SSText>
-              <View style={styles.qrCodeWrapper}>
-                <SSQRCode
-                  value={qrModal.value}
-                  size={220}
-                  color={Colors.white}
-                  backgroundColor={Colors.gray[950]}
-                  ecl="H"
-                />
-              </View>
-              <View style={styles.qrModalDataBox}>
-                <ShadedNostrKeyText
-                  value={qrModal.value}
-                  size="sm"
-                  lineBreakEvery={NOSTR_KEY_LINE_BREAK_EVERY}
-                  style={styles.qrModalDataText}
-                />
-              </View>
+              <SSShareableQR
+                value={qrModal.value}
+                size={220}
+                color={Colors.white}
+                backgroundColor={Colors.gray[950]}
+                ecl="H"
+                containerStyle={styles.qrCodeWrapper}
+                hideShareButton={qrModal.type !== 'npub'}
+              >
+                <View style={styles.qrModalDataBox}>
+                  <ShadedNostrKeyText
+                    value={qrModal.value}
+                    size="sm"
+                    lineBreakEvery={NOSTR_KEY_LINE_BREAK_EVERY}
+                    style={styles.qrModalDataText}
+                  />
+                </View>
+              </SSShareableQR>
             </>
           )}
         </SSVStack>

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/nostr/account/[npub]/note.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/nostr/account/[npub]/note.tsx
@@ -37,7 +37,7 @@ import SSNostrPollOptions from '@/components/SSNostrPollOptions'
 import SSNoteInlineImages from '@/components/SSNoteInlineImages'
 import SSNoteInlineVideos from '@/components/SSNoteInlineVideos'
 import SSPaymentMethodPicker from '@/components/SSPaymentMethodPicker'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import SSZapAmountDisplay from '@/components/SSZapAmountDisplay'
 import {
@@ -1972,26 +1972,26 @@ export default function NostrNotePage() {
           <SSText center uppercase>
             {t('nostrIdentity.note.qrTitle')}
           </SSText>
-          <View style={styles.qrContainer}>
-            <SSQRCode
-              value={noteNeventId}
-              size={260}
-              color={Colors.black}
-              backgroundColor={Colors.white}
-            />
-          </View>
-          <SSClipboardCopy text={noteNeventId}>
-            <SSText
-              center
-              size="xxs"
-              type="mono"
-              color="muted"
-              numberOfLines={2}
-              ellipsizeMode="middle"
-            >
-              {noteNeventId}
-            </SSText>
-          </SSClipboardCopy>
+          <SSShareableQR
+            value={noteNeventId}
+            size={260}
+            color={Colors.black}
+            backgroundColor={Colors.white}
+            containerStyle={styles.qrContainer}
+          >
+            <SSClipboardCopy text={noteNeventId}>
+              <SSText
+                center
+                size="xxs"
+                type="mono"
+                color="muted"
+                numberOfLines={2}
+                ellipsizeMode="middle"
+              >
+                {noteNeventId}
+              </SSText>
+            </SSClipboardCopy>
+          </SSShareableQR>
         </SSVStack>
       </SSModal>
 

--- a/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/nostr/create/index.tsx
+++ b/apps/mobile/app/(authenticated)/(tabs)/(signer,explorer,converter)/signer/nostr/create/index.tsx
@@ -5,8 +5,8 @@ import { Modal, ScrollView, StyleSheet, View } from 'react-native'
 import { toast } from 'sonner-native'
 
 import SSButton from '@/components/SSButton'
-import SSQRCode from '@/components/SSQRCode'
 import SSSeedQR from '@/components/SSSeedQR'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import { NOSTR_HIDDEN_KEY_MASK_LONG } from '@/constants/nostr'
 import SSHStack from '@/layouts/SSHStack'
@@ -201,10 +201,17 @@ export default function CreateNostrIdentity() {
         <View style={styles.qrOverlay}>
           <View style={styles.qrSheet}>
             <SSVStack itemsCenter gap="md">
-              {qrModalValue && <SSQRCode value={qrModalValue} size={240} />}
-              <SSText size="xs" type="mono" center numberOfLines={3}>
-                {qrModalValue}
-              </SSText>
+              {qrModalValue && (
+                <SSShareableQR
+                  value={qrModalValue}
+                  size={240}
+                  hideShareButton={qrModalValue !== keys.npub}
+                >
+                  <SSText size="xs" type="mono" center numberOfLines={3}>
+                    {qrModalValue}
+                  </SSText>
+                </SSShareableQR>
+              )}
               <SSButton
                 label={t('common.close')}
                 variant="ghost"

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -68,6 +68,20 @@ export default function RootLayout() {
 
   const appState = useRef(AppState.currentState)
   const [privacyScreenVisible, setPrivacyScreenVisible] = useState(false)
+  const [authHydrated, setAuthHydrated] = useState(() =>
+    useAuthStore.persist.hasHydrated()
+  )
+  const introOverlayVisible =
+    authHydrated && introVisible && (firstTime || introForceFirstTime)
+
+  useEffect(() => {
+    if (authHydrated) {
+      return
+    }
+    return useAuthStore.persist.onFinishHydration(() => {
+      setAuthHydrated(true)
+    })
+  }, [authHydrated])
 
   useEffect(() => {
     if (!firstTime) {
@@ -141,12 +155,12 @@ export default function RootLayout() {
               </View>
             </ThemeProvider>
             {privacyScreenVisible && <View style={styles.privacyScreen} />}
-            {introVisible && (
+            {introOverlayVisible ? (
               <SSIntroAnimation
                 firstTime={firstTime || introForceFirstTime}
                 onComplete={hideIntro}
               />
-            )}
+            ) : null}
             <SSImageActionsSheet />
             <Toaster
               theme="dark"

--- a/apps/mobile/components/SSContactProfileQrOverlay.tsx
+++ b/apps/mobile/components/SSContactProfileQrOverlay.tsx
@@ -1,5 +1,5 @@
 import { FlashList } from '@shopify/flash-list'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   type NativeScrollEvent,
   type NativeSyntheticEvent,
@@ -11,6 +11,7 @@ import {
 import SSClipboardCopy from '@/components/SSClipboardCopy'
 import SSModal from '@/components/SSModal'
 import SSQRCode from '@/components/SSQRCode'
+import SSShareButton from '@/components/SSShareButton'
 import SSText from '@/components/SSText'
 import {
   NOSTR_CONTACT_QR_CODE_SIZE,
@@ -58,6 +59,7 @@ function ContactQrPlaceholder({ label }: { label: string }) {
 
 function ContactQrItem({ label, value }: ContactQrItemProps) {
   const [inverted, setInverted] = useState(false)
+  const qrRef = useRef<View>(null)
 
   function handleToggleInvert() {
     setInverted((current) => !current)
@@ -72,7 +74,9 @@ function ContactQrItem({ label, value }: ContactQrItemProps) {
         {label}
       </SSText>
       <Pressable
+        ref={qrRef}
         accessibilityRole="button"
+        collapsable={false}
         onPress={handleToggleInvert}
         style={[
           styles.qrContainer,
@@ -99,6 +103,7 @@ function ContactQrItem({ label, value }: ContactQrItemProps) {
           {value}
         </SSText>
       </SSClipboardCopy>
+      <SSShareButton qrRef={qrRef} />
     </SSVStack>
   )
 }

--- a/apps/mobile/components/SSIntroAnimationCoordinationStep.tsx
+++ b/apps/mobile/components/SSIntroAnimationCoordinationStep.tsx
@@ -138,9 +138,7 @@ const COORDINATION_EDGES = [
   [0, 5]
 ] as const
 
-type CoordinationNodeShape = 'circle' | 'phone'
-
-type CoordinationNodeProps = {
+type CoordinationRevealNodeProps = {
   cx: number
   cy: number
   cycleScript: SharedValue<number>
@@ -151,9 +149,14 @@ type CoordinationNodeProps = {
   revealProgress: SharedValue<number>
   screenHeight: number
   screenWidth: number
-  shape: CoordinationNodeShape
   signEventStartMs: number | null
   size: number
+}
+
+function smoothReveal(progress: number, index: number) {
+  'worklet'
+  const raw = Math.min(1, Math.max(0, progress - index))
+  return raw * raw * (3 - 2 * raw)
 }
 
 const PHONE_WIDTH_RATIO = 0.58
@@ -270,30 +273,49 @@ function CoordinationPulse({
   )
 }
 
-function CoordinationNode({
-  cx,
-  cy,
-  size,
-  shape,
-  label,
-  npub,
-  opacity,
-  index,
-  revealProgress,
-  cycleScript,
-  signEventStartMs,
-  screenWidth,
-  screenHeight
-}: CoordinationNodeProps) {
+function useNodeBreathe(index: number) {
   const breathe = useSharedValue(1)
-  const eventDuration =
-    shape === 'circle' ? SIGNING_DESCRIPTOR_POP_MS : SIGNING_FLASH_MS
-  const eventScalePeak = shape === 'circle' ? 0.2 : 0.15
 
+  useEffect(() => {
+    breathe.set(
+      withDelay(
+        index * 420,
+        withRepeat(
+          withTiming(1.06, {
+            duration: 2800 + index * 90,
+            easing: Easing.inOut(Easing.sin)
+          }),
+          -1,
+          true
+        )
+      )
+    )
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  return breathe
+}
+
+function useNodeRevealStyles({
+  breathe,
+  cycleScript,
+  eventDuration,
+  eventScalePeak,
+  index,
+  opacity,
+  revealProgress,
+  signEventStartMs
+}: {
+  breathe: SharedValue<number>
+  cycleScript: SharedValue<number>
+  eventDuration: number
+  eventScalePeak: number
+  index: number
+  opacity: number
+  revealProgress: SharedValue<number>
+  signEventStartMs: number | null
+}) {
   const animStyle = useAnimatedStyle(() => {
-    const raw = Math.min(1, Math.max(0, revealProgress.value - index))
-    const smooth = raw * raw * (3 - 2 * raw)
-
+    const smooth = smoothReveal(revealProgress.value, index)
     let eventScaleBoost = 0
     if (signEventStartMs !== null) {
       const t = (cycleScript.value - signEventStartMs) / eventDuration
@@ -312,8 +334,72 @@ function CoordinationNode({
     }
   })
 
+  const labelStyle = useAnimatedStyle(() => ({
+    opacity: 0.7 * smoothReveal(revealProgress.value, index)
+  }))
+
+  const npubStyle = useAnimatedStyle(() => ({
+    opacity: 0.4 * smoothReveal(revealProgress.value, index)
+  }))
+
+  return { animStyle, labelStyle, npubStyle }
+}
+
+function useSigningIndicatorStyle(
+  cycleScript: SharedValue<number>,
+  arrivalMs: number
+) {
+  return useAnimatedStyle(() => {
+    const t = (cycleScript.value - arrivalMs) / SIGNING_INDICATOR_FADE_MS
+    const progress = t <= 0 ? 0 : Math.min(1, t)
+    const checkT =
+      (cycleScript.value - SIGNING_CHECK_REVEAL_START_MS) /
+      SIGNING_CHECK_REVEAL_MS
+    const checkProgress = checkT <= 0 ? 0 : Math.min(1, checkT)
+    return {
+      backgroundColor: interpolateColor(
+        progress,
+        [0, 1],
+        [Colors.white, Colors.black]
+      ),
+      borderColor: interpolateColor(
+        progress,
+        [0, 1],
+        [Colors.gray[75], Colors.black]
+      ),
+      opacity: 1 - checkProgress
+    }
+  })
+}
+
+function PhoneNode({
+  cx,
+  cy,
+  cycleScript,
+  index,
+  label,
+  npub,
+  opacity,
+  revealProgress,
+  screenHeight,
+  screenWidth,
+  signEventStartMs,
+  size
+}: CoordinationRevealNodeProps) {
+  const breathe = useNodeBreathe(index)
+  const { animStyle, labelStyle, npubStyle } = useNodeRevealStyles({
+    breathe,
+    cycleScript,
+    eventDuration: SIGNING_FLASH_MS,
+    eventScalePeak: 0.15,
+    index,
+    opacity,
+    revealProgress,
+    signEventStartMs
+  })
+
   const borderStyle = useAnimatedStyle(() => {
-    if (signEventStartMs === null || shape !== 'phone') {
+    if (signEventStartMs === null) {
       return { borderColor: Colors.gray[700] }
     }
     const t = (cycleScript.value - signEventStartMs) / SIGNING_FLASH_MS
@@ -327,90 +413,99 @@ function CoordinationNode({
     }
   })
 
-  const labelStyle = useAnimatedStyle(() => {
-    const raw = Math.min(1, Math.max(0, revealProgress.value - index))
-    const smooth = raw * raw * (3 - 2 * raw)
-    return { opacity: 0.7 * smooth }
-  })
+  const phoneHeight = size
+  const phoneWidth = Math.max(8, size * PHONE_WIDTH_RATIO)
+  const cornerRadius = Math.max(1, size * PHONE_CORNER_RATIO)
+  const labelTop = cy * screenHeight + phoneHeight / 2 + PHONE_LABEL_GAP
+  const npubTop = labelTop + PHONE_LABEL_LINE_HEIGHT + PHONE_NPUB_GAP
 
-  const npubStyle = useAnimatedStyle(() => {
-    const raw = Math.min(1, Math.max(0, revealProgress.value - index))
-    const smooth = raw * raw * (3 - 2 * raw)
-    return { opacity: 0.4 * smooth }
-  })
+  return (
+    <>
+      <Animated.View
+        style={[
+          styles.coordinationPhone,
+          animStyle,
+          borderStyle,
+          {
+            borderRadius: cornerRadius,
+            height: phoneHeight,
+            left: cx * screenWidth - phoneWidth / 2,
+            top: cy * screenHeight - phoneHeight / 2,
+            width: phoneWidth
+          }
+        ]}
+      />
+      {label !== null ? (
+        <Animated.Text
+          style={[
+            styles.coordinationPhoneLabel,
+            labelStyle,
+            {
+              left: cx * screenWidth - PHONE_LABEL_WIDTH / 2,
+              top: labelTop,
+              width: PHONE_LABEL_WIDTH
+            }
+          ]}
+        >
+          {label}
+        </Animated.Text>
+      ) : null}
+      {npub !== null ? (
+        <Animated.Text
+          style={[
+            styles.coordinationPhoneNpub,
+            npubStyle,
+            {
+              left: cx * screenWidth - PHONE_LABEL_WIDTH / 2,
+              top: npubTop,
+              width: PHONE_LABEL_WIDTH
+            }
+          ]}
+        >
+          {npub}
+        </Animated.Text>
+      ) : null}
+    </>
+  )
+}
 
-  const indicator0Style = useAnimatedStyle(() => {
-    const t =
-      (cycleScript.value - SIGNING_INDICATOR_ARRIVAL_MS[0]) /
-      SIGNING_INDICATOR_FADE_MS
-    const progress = t <= 0 ? 0 : Math.min(1, t)
-    const checkT =
-      (cycleScript.value - SIGNING_CHECK_REVEAL_START_MS) /
-      SIGNING_CHECK_REVEAL_MS
-    const checkProgress = checkT <= 0 ? 0 : Math.min(1, checkT)
-    return {
-      backgroundColor: interpolateColor(
-        progress,
-        [0, 1],
-        [Colors.white, Colors.black]
-      ),
-      borderColor: interpolateColor(
-        progress,
-        [0, 1],
-        [Colors.gray[75], Colors.black]
-      ),
-      opacity: 1 - checkProgress
-    }
+function DescriptorNode({
+  cx,
+  cy,
+  cycleScript,
+  index,
+  label,
+  npub,
+  opacity,
+  revealProgress,
+  screenHeight,
+  screenWidth,
+  signEventStartMs,
+  size
+}: CoordinationRevealNodeProps) {
+  const breathe = useNodeBreathe(index)
+  const { animStyle, labelStyle, npubStyle } = useNodeRevealStyles({
+    breathe,
+    cycleScript,
+    eventDuration: SIGNING_DESCRIPTOR_POP_MS,
+    eventScalePeak: 0.2,
+    index,
+    opacity,
+    revealProgress,
+    signEventStartMs
   })
-
-  const indicator1Style = useAnimatedStyle(() => {
-    const t =
-      (cycleScript.value - SIGNING_INDICATOR_ARRIVAL_MS[1]) /
-      SIGNING_INDICATOR_FADE_MS
-    const progress = t <= 0 ? 0 : Math.min(1, t)
-    const checkT =
-      (cycleScript.value - SIGNING_CHECK_REVEAL_START_MS) /
-      SIGNING_CHECK_REVEAL_MS
-    const checkProgress = checkT <= 0 ? 0 : Math.min(1, checkT)
-    return {
-      backgroundColor: interpolateColor(
-        progress,
-        [0, 1],
-        [Colors.white, Colors.black]
-      ),
-      borderColor: interpolateColor(
-        progress,
-        [0, 1],
-        [Colors.gray[75], Colors.black]
-      ),
-      opacity: 1 - checkProgress
-    }
-  })
-
-  const indicator2Style = useAnimatedStyle(() => {
-    const t =
-      (cycleScript.value - SIGNING_INDICATOR_ARRIVAL_MS[2]) /
-      SIGNING_INDICATOR_FADE_MS
-    const progress = t <= 0 ? 0 : Math.min(1, t)
-    const checkT =
-      (cycleScript.value - SIGNING_CHECK_REVEAL_START_MS) /
-      SIGNING_CHECK_REVEAL_MS
-    const checkProgress = checkT <= 0 ? 0 : Math.min(1, checkT)
-    return {
-      backgroundColor: interpolateColor(
-        progress,
-        [0, 1],
-        [Colors.white, Colors.black]
-      ),
-      borderColor: interpolateColor(
-        progress,
-        [0, 1],
-        [Colors.gray[75], Colors.black]
-      ),
-      opacity: 1 - checkProgress
-    }
-  })
-
+  const indicator0Style = useSigningIndicatorStyle(
+    cycleScript,
+    SIGNING_INDICATOR_ARRIVAL_MS[0]
+  )
+  const indicator1Style = useSigningIndicatorStyle(
+    cycleScript,
+    SIGNING_INDICATOR_ARRIVAL_MS[1]
+  )
+  const indicator2Style = useSigningIndicatorStyle(
+    cycleScript,
+    SIGNING_INDICATOR_ARRIVAL_MS[2]
+  )
   const checkStyle = useAnimatedStyle(() => {
     const t =
       (cycleScript.value - SIGNING_CHECK_REVEAL_START_MS) /
@@ -422,79 +517,6 @@ function CoordinationNode({
       transform: [{ scale: 0.4 + smooth * 0.6 }]
     }
   })
-
-  useEffect(() => {
-    breathe.set(
-      withDelay(
-        index * 420,
-        withRepeat(
-          withTiming(1.06, {
-            duration: 2800 + index * 90,
-            easing: Easing.inOut(Easing.sin)
-          }),
-          -1,
-          true
-        )
-      )
-    )
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  if (shape === 'phone') {
-    const phoneHeight = size
-    const phoneWidth = Math.max(8, size * PHONE_WIDTH_RATIO)
-    const cornerRadius = Math.max(1, size * PHONE_CORNER_RATIO)
-    const labelTop = cy * screenHeight + phoneHeight / 2 + PHONE_LABEL_GAP
-    const npubTop = labelTop + PHONE_LABEL_LINE_HEIGHT + PHONE_NPUB_GAP
-
-    return (
-      <>
-        <Animated.View
-          style={[
-            styles.coordinationPhone,
-            animStyle,
-            borderStyle,
-            {
-              borderRadius: cornerRadius,
-              height: phoneHeight,
-              left: cx * screenWidth - phoneWidth / 2,
-              top: cy * screenHeight - phoneHeight / 2,
-              width: phoneWidth
-            }
-          ]}
-        />
-        {label !== null && (
-          <Animated.Text
-            style={[
-              styles.coordinationPhoneLabel,
-              labelStyle,
-              {
-                left: cx * screenWidth - PHONE_LABEL_WIDTH / 2,
-                top: labelTop,
-                width: PHONE_LABEL_WIDTH
-              }
-            ]}
-          >
-            {label}
-          </Animated.Text>
-        )}
-        {npub !== null && (
-          <Animated.Text
-            style={[
-              styles.coordinationPhoneNpub,
-              npubStyle,
-              {
-                left: cx * screenWidth - PHONE_LABEL_WIDTH / 2,
-                top: npubTop,
-                width: PHONE_LABEL_WIDTH
-              }
-            ]}
-          >
-            {npub}
-          </Animated.Text>
-        )}
-      </>
-    )
-  }
 
   const circleLabelTop = cy * screenHeight + size / 2 + PHONE_LABEL_GAP
   const circleNpubTop =
@@ -547,7 +569,7 @@ function CoordinationNode({
           </Svg>
         </Animated.View>
       </Animated.View>
-      {label !== null && (
+      {label !== null ? (
         <Animated.Text
           style={[
             styles.coordinationDescriptorLabel,
@@ -561,8 +583,8 @@ function CoordinationNode({
         >
           {label}
         </Animated.Text>
-      )}
-      {npub !== null && (
+      ) : null}
+      {npub !== null ? (
         <Animated.Text
           style={[
             styles.coordinationPhoneNpub,
@@ -576,7 +598,7 @@ function CoordinationNode({
         >
           {npub}
         </Animated.Text>
-      )}
+      ) : null}
     </>
   )
 }
@@ -744,24 +766,41 @@ function SSIntroAnimationCoordinationStep({
           })}
         </Svg>
       </View>
-      {COORDINATION_NODES.map((node, i) => (
-        <CoordinationNode
-          key={i}
-          index={i}
-          cx={node.cx}
-          cy={node.cy}
-          size={node.size}
-          shape={node.shape}
-          label={node.label}
-          npub={node.npub}
-          opacity={node.opacity}
-          revealProgress={revealProgress}
-          cycleScript={cycleScript}
-          signEventStartMs={node.signEventStartMs}
-          screenWidth={screenWidth}
-          screenHeight={screenHeight}
-        />
-      ))}
+      {COORDINATION_NODES.map((node, i) =>
+        node.shape === 'phone' ? (
+          <PhoneNode
+            key={i}
+            index={i}
+            cx={node.cx}
+            cy={node.cy}
+            size={node.size}
+            label={node.label}
+            npub={node.npub}
+            opacity={node.opacity}
+            revealProgress={revealProgress}
+            cycleScript={cycleScript}
+            signEventStartMs={node.signEventStartMs}
+            screenWidth={screenWidth}
+            screenHeight={screenHeight}
+          />
+        ) : (
+          <DescriptorNode
+            key={i}
+            index={i}
+            cx={node.cx}
+            cy={node.cy}
+            size={node.size}
+            label={node.label}
+            npub={node.npub}
+            opacity={node.opacity}
+            revealProgress={revealProgress}
+            cycleScript={cycleScript}
+            signEventStartMs={node.signEventStartMs}
+            screenWidth={screenWidth}
+            screenHeight={screenHeight}
+          />
+        )
+      )}
     </View>
   )
 }

--- a/apps/mobile/components/SSPsbtTransport.tsx
+++ b/apps/mobile/components/SSPsbtTransport.tsx
@@ -1,5 +1,5 @@
 import * as Clipboard from 'expo-clipboard'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { Dimensions, View } from 'react-native'
 import { toast } from 'sonner-native'
 
@@ -7,7 +7,7 @@ import SSButton from '@/components/SSButton'
 import SSCameraModal from '@/components/SSCameraModal'
 import SSModal from '@/components/SSModal'
 import SSNFCModal from '@/components/SSNFCModal'
-import SSQRCode from '@/components/SSQRCode'
+import SSShareableQR from '@/components/SSShareableQR'
 import SSText from '@/components/SSText'
 import { useNFCEmitter } from '@/hooks/useNFCEmitter'
 import { useNFCReader } from '@/hooks/useNFCReader'
@@ -48,6 +48,7 @@ function SSPsbtTransport({
   const [cameraVisible, setCameraVisible] = useState(false)
   const [nfcVisible, setNfcVisible] = useState(false)
   const [chunkIndex, setChunkIndex] = useState(0)
+  const qrRef = useRef<View>(null)
 
   const { isHardwareSupported: nfcWriteSupported } = useNFCEmitter()
   const { isHardwareSupported: nfcReadSupported } = useNFCReader()
@@ -180,35 +181,42 @@ function SSPsbtTransport({
           <SSVStack gap="md" style={{ alignItems: 'center' }}>
             <SSText uppercase>{t('common.psbtTransport.qrTitle')}</SSText>
             {qrValue ? (
-              <View
-                style={{
+              <SSShareableQR
+                qrRef={qrRef}
+                value={qrValue}
+                size={QR_SIZE}
+                color={Colors.black}
+                backgroundColor={Colors.white}
+                hideShareButton={qrChunks.length > 1}
+                containerStyle={{
                   alignItems: 'center',
                   backgroundColor: Colors.white,
                   borderRadius: 2,
                   padding: 8
                 }}
               >
-                <SSQRCode
-                  value={qrValue}
-                  size={QR_SIZE}
-                  color={Colors.black}
-                  backgroundColor={Colors.white}
-                />
-              </View>
+                {qrChunks.length > 1 ? (
+                  <SSText color="muted" size="sm" center>
+                    {t('common.psbtTransport.qrPart', {
+                      current: (chunkIndex % qrChunks.length) + 1,
+                      total: qrChunks.length
+                    })}
+                  </SSText>
+                ) : null}
+                <SSText color="muted" size="sm" center>
+                  {t('common.psbtTransport.qrHint')}
+                </SSText>
+              </SSShareableQR>
             ) : (
-              <SSText color="muted">{t('common.psbtTransport.qrError')}</SSText>
+              <>
+                <SSText color="muted">
+                  {t('common.psbtTransport.qrError')}
+                </SSText>
+                <SSText color="muted" size="sm" center>
+                  {t('common.psbtTransport.qrHint')}
+                </SSText>
+              </>
             )}
-            {qrChunks.length > 1 ? (
-              <SSText color="muted" size="sm" center>
-                {t('common.psbtTransport.qrPart', {
-                  current: (chunkIndex % qrChunks.length) + 1,
-                  total: qrChunks.length
-                })}
-              </SSText>
-            ) : null}
-            <SSText color="muted" size="sm" center>
-              {t('common.psbtTransport.qrHint')}
-            </SSText>
             <SSButton
               label={t('common.close')}
               variant="ghost"

--- a/apps/mobile/components/SSShareButton.tsx
+++ b/apps/mobile/components/SSShareButton.tsx
@@ -1,0 +1,75 @@
+import { type RefObject } from 'react'
+import { StyleSheet, type View } from 'react-native'
+import { toast } from 'sonner-native'
+
+import SSHStack from '@/layouts/SSHStack'
+import { t } from '@/locales'
+import { shareImage, shareText, shareViewAsImage } from '@/utils/share'
+
+import { SSIconShare } from './icons'
+import SSButton, { type SSButtonProps } from './SSButton'
+import SSText from './SSText'
+
+type SSShareButtonBaseProps = {
+  dialogTitle?: string
+} & Omit<SSButtonProps, 'label' | 'icon' | 'variant' | 'onPress'>
+
+export type SSShareButtonProps = SSShareButtonBaseProps &
+  (
+    | { content: string; type?: 'text' | 'image'; qrRef?: undefined }
+    | { qrRef: RefObject<View | null>; content?: undefined; type?: undefined }
+  )
+
+function SSShareButton({
+  content,
+  type = 'text',
+  qrRef,
+  dialogTitle,
+  ...props
+}: SSShareButtonProps) {
+  async function handleShare() {
+    if (qrRef) {
+      try {
+        await shareViewAsImage({
+          dialogTitle: dialogTitle ?? t('common.share'),
+          viewRef: qrRef
+        })
+      } catch {
+        toast.error(t('common.shareError'))
+      }
+      return
+    }
+    if (type === 'image') {
+      await shareImage({
+        dialogTitle: dialogTitle ?? t('common.share'),
+        uri: content
+      })
+      return
+    }
+    await shareText({ content, dialogTitle })
+  }
+
+  return (
+    <SSButton
+      variant="outline"
+      onPress={handleShare}
+      icon={
+        <SSHStack gap="xs">
+          <SSText uppercase color="white" style={styles.label}>
+            {t('common.share')}
+          </SSText>
+          <SSIconShare height={16} width={16} stroke="#FFFFFF" />
+        </SSHStack>
+      }
+      {...props}
+    />
+  )
+}
+
+const styles = StyleSheet.create({
+  label: {
+    letterSpacing: 1
+  }
+})
+
+export default SSShareButton

--- a/apps/mobile/components/SSShareableQR.tsx
+++ b/apps/mobile/components/SSShareableQR.tsx
@@ -1,0 +1,50 @@
+import { type ReactNode, type RefObject, useRef } from 'react'
+import { type StyleProp, View, type ViewStyle } from 'react-native'
+
+import SSQRCode from './SSQRCode'
+import SSShareButton from './SSShareButton'
+
+type SSShareableQRProps = {
+  value: string
+  size?: number
+  ecl?: 'H' | 'Q' | 'M' | 'L'
+  color?: string
+  backgroundColor?: string
+  containerStyle?: StyleProp<ViewStyle>
+  qrRef?: RefObject<View | null>
+  hideShareButton?: boolean
+  children?: ReactNode
+}
+
+function SSShareableQR({
+  value,
+  size,
+  ecl,
+  color,
+  backgroundColor,
+  containerStyle,
+  qrRef: externalRef,
+  hideShareButton = false,
+  children
+}: SSShareableQRProps) {
+  const internalRef = useRef<View>(null)
+  const qrRef = externalRef ?? internalRef
+
+  return (
+    <>
+      <View collapsable={false} ref={qrRef} style={containerStyle}>
+        <SSQRCode
+          value={value}
+          size={size}
+          ecl={ecl}
+          color={color}
+          backgroundColor={backgroundColor}
+        />
+      </View>
+      {children}
+      {!hideShareButton && <SSShareButton qrRef={qrRef} />}
+    </>
+  )
+}
+
+export default SSShareableQR

--- a/apps/mobile/components/SSTransactionChart.tsx
+++ b/apps/mobile/components/SSTransactionChart.tsx
@@ -155,6 +155,8 @@ function SSTransactionChart(props: SSTransactionChartProps) {
   const [mountCanvas, setMountCanvas] = useState(false)
 
   useEffect(() => {
+    // requestIdleCallback replaces deprecated InteractionManager.runAfterInteractions.
+    // Frame-tick driven: pauses while backgrounded; does not wait for UI-thread animations.
     const idleHandle = requestIdleCallback(() => {
       setMountCanvas(true)
     })

--- a/apps/mobile/components/icons/SSIconShare.tsx
+++ b/apps/mobile/components/icons/SSIconShare.tsx
@@ -1,0 +1,28 @@
+import Svg, { Path, type SvgProps } from 'react-native-svg'
+
+type IconProps = Pick<SvgProps, 'width' | 'height' | 'stroke'>
+
+export default function SSIconShare({
+  width = 16,
+  height = 16,
+  stroke = '#828282'
+}: IconProps) {
+  return (
+    <Svg width={width} height={height} viewBox="0 0 24 24" fill="none">
+      <Path
+        d="M12 16V4M7 8l5-5 5 5"
+        stroke={stroke}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <Path
+        d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-7"
+        stroke={stroke}
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </Svg>
+  )
+}

--- a/apps/mobile/components/icons/index.tsx
+++ b/apps/mobile/components/icons/index.tsx
@@ -95,6 +95,7 @@ import SSIconSeed from './SSIconSeed'
 import SSIconServer from './SSIconServer'
 import SSIconServerOptions from './SSIconServerOptions'
 import SSIconSettings from './SSIconSettings'
+import SSIconShare from './SSIconShare'
 import SSIconSigner from './SSIconSigner'
 import SSIconSignerActive from './SSIconSignerActive'
 import SSIconSignOut from './SSIconSignOut'
@@ -209,6 +210,7 @@ export {
   SSIconServer,
   SSIconServerOptions,
   SSIconSettings,
+  SSIconShare,
   SSIconSigner,
   SSIconSignerActive,
   SSIconSignOut,

--- a/apps/mobile/hooks/useNostrMessageProcessor.ts
+++ b/apps/mobile/hooks/useNostrMessageProcessor.ts
@@ -96,7 +96,9 @@ function useNostrMessageProcessor() {
         return
       }
 
-      // Defer until the JS thread is idle so we don't block navigation/animations.
+      // requestIdleCallback replaces deprecated InteractionManager.runAfterInteractions.
+      // It is frame-tick driven: it pauses while the app is backgrounded and does
+      // not wait for UI-thread animations to finish.
       await new Promise<void>((resolve) => {
         requestIdleCallback(() => resolve())
       })

--- a/apps/mobile/locales/en.json
+++ b/apps/mobile/locales/en.json
@@ -913,6 +913,7 @@
     "selected": "Selected",
     "separator": "·",
     "share": "Share",
+    "shareError": "Unable to share",
     "show": "Show",
     "showLess": "Show less",
     "showMore": "Show more",

--- a/apps/mobile/store/intro.ts
+++ b/apps/mobile/store/intro.ts
@@ -17,4 +17,9 @@ const useIntroStore = create<IntroState & IntroAction>((set) => ({
   visible: true
 }))
 
-export { useIntroStore }
+function shouldShowIntro(firstTime: boolean): boolean {
+  const { forceFirstTime, visible } = useIntroStore.getState()
+  return visible && (firstTime || forceFirstTime)
+}
+
+export { shouldShowIntro, useIntroStore }

--- a/apps/mobile/tests/unit/store/intro.test.ts
+++ b/apps/mobile/tests/unit/store/intro.test.ts
@@ -1,0 +1,57 @@
+import { shouldShowIntro, useIntroStore } from '@/store/intro'
+
+const INTRO_INITIAL_STATE = {
+  forceFirstTime: false,
+  visible: true
+}
+
+describe('useIntroStore', () => {
+  beforeEach(() => {
+    useIntroStore.setState(INTRO_INITIAL_STATE)
+  })
+
+  it('defaults to visible without forcing the first-time path', () => {
+    const { forceFirstTime, visible } = useIntroStore.getState()
+    expect(visible).toBe(true)
+    expect(forceFirstTime).toBe(false)
+  })
+
+  it('does not overlay a returning user until replay is requested', () => {
+    expect(shouldShowIntro(false)).toBe(false)
+    expect(shouldShowIntro(true)).toBe(true)
+  })
+
+  it('hideIntro dismisses the overlay even while firstTime is still true', () => {
+    useIntroStore.getState().hideIntro()
+    expect(useIntroStore.getState().visible).toBe(false)
+    expect(shouldShowIntro(true)).toBe(false)
+  })
+
+  it('showIntro(true) forces the first-time path for About replay', () => {
+    useIntroStore.setState({ forceFirstTime: false, visible: false })
+    useIntroStore.getState().showIntro(true)
+    expect(useIntroStore.getState()).toMatchObject({
+      forceFirstTime: true,
+      visible: true
+    })
+    expect(shouldShowIntro(false)).toBe(true)
+  })
+
+  it('showIntro() without force does not cover a returning user', () => {
+    useIntroStore.setState({ forceFirstTime: false, visible: false })
+    useIntroStore.getState().showIntro()
+    expect(useIntroStore.getState().forceFirstTime).toBe(false)
+    expect(shouldShowIntro(false)).toBe(false)
+    expect(shouldShowIntro(true)).toBe(true)
+  })
+
+  it('hideIntro clears forceFirstTime after a forced replay', () => {
+    useIntroStore.getState().showIntro(true)
+    useIntroStore.getState().hideIntro()
+    expect(useIntroStore.getState()).toMatchObject({
+      forceFirstTime: false,
+      visible: false
+    })
+    expect(shouldShowIntro(false)).toBe(false)
+  })
+})

--- a/apps/mobile/tests/unit/utils/share.test.ts
+++ b/apps/mobile/tests/unit/utils/share.test.ts
@@ -1,0 +1,146 @@
+import { type RefObject } from 'react'
+import { Share, type View } from 'react-native'
+import { captureRef } from 'react-native-view-shot'
+
+import { shareExistingFile } from '@/utils/filesystem'
+import { shareImage, shareText, shareViewAsImage } from '@/utils/share'
+
+jest.mock<typeof import('@/utils/filesystem')>('@/utils/filesystem', () => ({
+  shareExistingFile: jest.fn()
+}))
+
+jest.mock<typeof import('react-native')>('react-native', () => ({
+  Share: { share: jest.fn() }
+}))
+
+jest.mock<typeof import('react-native-view-shot')>(
+  'react-native-view-shot',
+  () => ({
+    captureRef: jest.fn()
+  })
+)
+
+const mockShare = jest.mocked(Share.share)
+const mockShareExistingFile = jest.mocked(shareExistingFile)
+const mockCaptureRef = jest.mocked(captureRef)
+
+describe('shareText', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shares the message without options when no dialog title is given', async () => {
+    mockShare.mockResolvedValueOnce({ action: 'sharedAction' })
+
+    await shareText({ content: 'hello world' })
+
+    expect(mockShare).toHaveBeenCalledWith(
+      { message: 'hello world' },
+      undefined
+    )
+  })
+
+  it('passes the dialog title through as share options', async () => {
+    mockShare.mockResolvedValueOnce({ action: 'sharedAction' })
+
+    await shareText({ content: 'hello world', dialogTitle: 'Share note' })
+
+    expect(mockShare).toHaveBeenCalledWith(
+      { message: 'hello world' },
+      { dialogTitle: 'Share note' }
+    )
+  })
+
+  it('silently ignores a share failure', async () => {
+    mockShare.mockRejectedValueOnce(new Error('cancelled'))
+
+    await expect(shareText({ content: 'hello' })).resolves.toBeUndefined()
+  })
+})
+
+describe('shareImage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('shares the image file with the default mime type', async () => {
+    mockShareExistingFile.mockResolvedValueOnce(undefined)
+
+    await shareImage({ dialogTitle: 'Share QR', uri: 'file:///qr.png' })
+
+    expect(mockShareExistingFile).toHaveBeenCalledWith({
+      dialogTitle: 'Share QR',
+      fileUri: 'file:///qr.png',
+      mimeType: 'image/png'
+    })
+  })
+
+  it('silently ignores a share failure', async () => {
+    mockShareExistingFile.mockRejectedValueOnce(new Error('unavailable'))
+
+    await expect(
+      shareImage({ dialogTitle: 'Share QR', uri: 'file:///qr.png' })
+    ).resolves.toBeUndefined()
+  })
+})
+
+describe('shareViewAsImage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  function refWithView(current: View | null): RefObject<View | null> {
+    return { current }
+  }
+
+  it('does nothing when the ref has no attached view', async () => {
+    await shareViewAsImage({
+      dialogTitle: 'Share QR',
+      viewRef: refWithView(null)
+    })
+
+    expect(mockCaptureRef).not.toHaveBeenCalled()
+    expect(mockShareExistingFile).not.toHaveBeenCalled()
+  })
+
+  it('captures the view as PNG and shares the resulting file', async () => {
+    const view = {} as View
+    mockCaptureRef.mockResolvedValueOnce('file:///cache/qr-capture.png')
+    mockShareExistingFile.mockResolvedValueOnce(undefined)
+
+    await shareViewAsImage({
+      dialogTitle: 'Share QR',
+      viewRef: refWithView(view)
+    })
+
+    expect(mockCaptureRef).toHaveBeenCalledWith(refWithView(view), {
+      format: 'png',
+      result: 'tmpfile'
+    })
+    expect(mockShareExistingFile).toHaveBeenCalledWith({
+      dialogTitle: 'Share QR',
+      fileUri: 'file:///cache/qr-capture.png',
+      mimeType: 'image/png'
+    })
+  })
+
+  it('propagates a capture failure so the caller can surface it', async () => {
+    const view = {} as View
+    mockCaptureRef.mockRejectedValueOnce(new Error('capture failed'))
+
+    await expect(
+      shareViewAsImage({ dialogTitle: 'Share QR', viewRef: refWithView(view) })
+    ).rejects.toThrow('capture failed')
+    expect(mockShareExistingFile).not.toHaveBeenCalled()
+  })
+
+  it('silently ignores a share failure after a successful capture', async () => {
+    const view = {} as View
+    mockCaptureRef.mockResolvedValueOnce('file:///cache/qr-capture.png')
+    mockShareExistingFile.mockRejectedValueOnce(new Error('unavailable'))
+
+    await expect(
+      shareViewAsImage({ dialogTitle: 'Share QR', viewRef: refWithView(view) })
+    ).resolves.toBeUndefined()
+  })
+})

--- a/apps/mobile/utils/share.ts
+++ b/apps/mobile/utils/share.ts
@@ -1,0 +1,66 @@
+import { type RefObject } from 'react'
+import { Share, type View } from 'react-native'
+import { captureRef } from 'react-native-view-shot'
+
+import { shareExistingFile } from '@/utils/filesystem'
+
+type ShareTextProps = {
+  content: string
+  dialogTitle?: string
+}
+
+export async function shareText({
+  content,
+  dialogTitle
+}: ShareTextProps): Promise<void> {
+  try {
+    await Share.share(
+      { message: content },
+      dialogTitle ? { dialogTitle } : undefined
+    )
+  } catch {
+    /* sharing cancelled or unavailable — silently ignored */
+  }
+}
+
+type ShareImageProps = {
+  uri: string
+  dialogTitle: string
+  mimeType?: string
+}
+
+export async function shareImage({
+  uri,
+  dialogTitle,
+  mimeType = 'image/png'
+}: ShareImageProps): Promise<void> {
+  try {
+    await shareExistingFile({ dialogTitle, fileUri: uri, mimeType })
+  } catch {
+    /* sharing cancelled or unavailable — silently ignored */
+  }
+}
+
+type ShareViewAsImageProps = {
+  viewRef: RefObject<View | null>
+  dialogTitle: string
+}
+
+export async function shareViewAsImage({
+  viewRef,
+  dialogTitle
+}: ShareViewAsImageProps): Promise<void> {
+  if (!viewRef.current) {
+    return
+  }
+  const uri = await captureRef(viewRef, { format: 'png', result: 'tmpfile' })
+  try {
+    await shareExistingFile({
+      dialogTitle,
+      fileUri: uri,
+      mimeType: 'image/png'
+    })
+  } catch {
+    /* sharing cancelled or unavailable — silently ignored */
+  }
+}


### PR DESCRIPTION
## Summary
- Native LND REST pairing (lndconnect, JSON, TLS/HTTP2) plus on-chain send/receive, open channel, invoice polling, and lightning node backup.
- Ecash MPP/mint routing, full-mint backups, and restore from seed or pasted backup JSON.
- Toolbar/sort alignment and backup helpers extracted out of page components.

## Test plan
- [ ] Pair an LND node via lndconnect (clearnet and onion) and via pairing JSON
- [ ] Receive a lightning invoice and confirm polling updates status
- [ ] Send on-chain from LND and open a channel from node settings
- [ ] Export a lightning/ecash backup, then restore on a fresh account
- [ ] Restore ecash proofs from seed (all mints) and from pasted backup JSON
- [ ] Pay a lightning invoice from ecash with single-mint and MPP multi-mint paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Open Lightning channels with peer entry or QR scanning, funding options, and review before confirmation.
  * Create and share configurable Lightning node backups.
  * Pay Lightning invoices using balances across multiple eCash mints.
  * Restore eCash backups across multiple mints while preserving existing data.
  * Connect to Lightning nodes using RPC pairing.

* **Bug Fixes**
  * Pending eCash proofs are now retained as valid.
  * Improved invoice amount validation and payment error reporting.
  * More reliable Lightning and blockchain backup validation and restoration.
  * Improved handling of payment fees, balances, and consumed proofs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->